### PR TITLE
feat: PM workflow scaffolding — README pointer, weekly meeting workflow, audit trail

### DIFF
--- a/.claude/commands/process-meeting.md
+++ b/.claude/commands/process-meeting.md
@@ -1,0 +1,163 @@
+# Process Cortex Weekly Standup
+
+Process a weekly Cortex team meeting transcript: produce a Change Brief, checkpoint with Mariam, execute approved changes, commit audit trail.
+
+## Usage
+
+```
+/process-meeting
+```
+
+Then paste the transcript in the next message (or paste it inline with the command).
+
+---
+
+## Workflow
+
+### Step 0 — Pre-flight: Context cost check
+
+**Before reading anything**, report the size of files about to be loaded:
+
+```bash
+ls -la "/Users/mariamtbackbase.com/VS Code manual inputs/Cortex PM/Cortex_Context.md" \
+       "/Users/mariamtbackbase.com/VS Code manual inputs/Cortex PM/"Cortex_Release_Plan_*.md 2>&1
+```
+
+Sum the file sizes. Report:
+- Total KB about to be read
+- Whether any file exceeds 10 KB (soft limit — flag for refactoring if so)
+
+If total > 30 KB, **stop and ask Mariam** whether to proceed or refactor first. The whole point of this workflow is to stay bounded.
+
+### Step 1 — Ingest transcript
+
+The transcript is in Mariam's message. If not present, ask for it.
+
+Save a dated archive at:
+```
+/Users/mariamtbackbase.com/VS Code manual inputs/Cortex PM/meetings/YYYY-MM-DD_standup.md
+```
+
+Use today's date from system context. Include a one-line header (`# Cortex Standup — YYYY-MM-DD`) above the verbatim transcript.
+
+### Step 2 — Read context
+
+Read in order:
+1. `Cortex_Context.md` — glossary, team, concepts, standing decisions
+2. Latest `Cortex_Release_Plan_*.md` — current release plan + open items
+3. Query live board state:
+   ```bash
+   gh issue list --repo mayur294-lgtm/value-consulting-agents --state open --limit 60 \
+     --json number,title,assignees,milestone,labels
+   gh api repos/mayur294-lgtm/value-consulting-agents/milestones --jq '.[] | "\(.number) \(.title) — due \(.due_on) — \(.state)"'
+   ```
+
+Do NOT read prior meeting archives unless something in this week's transcript references a prior decision you can't verify from current state.
+
+### Step 3 — Produce Change Brief
+
+Output a structured brief covering ALL sections below. Use this exact template:
+
+```markdown
+## Change Brief — YYYY-MM-DD Standup
+
+### Decisions made
+- [Decision] (cross-ref: issue # / prior commitment)
+
+### New commitments
+| Owner | Commitment | By when |
+|---|---|---|
+
+### Status changes needed
+| # | Current | New | Reason |
+|---|---|---|---|
+
+### Schedule/milestone changes
+- [Specific change with date]
+
+### New issues to create
+| Title | Owner | Milestone | Body summary |
+|---|---|---|---|
+
+### Doc edits needed
+| File | Section | Change |
+|---|---|---|
+
+### Open questions / ambiguities
+1. [Question Mariam must answer before execution]
+
+### Knowledge to capture in Cortex_Context.md
+- [New concept / acronym / decision]
+```
+
+Save the brief to:
+```
+/Users/mariamtbackbase.com/VS Code manual inputs/Cortex PM/meetings/YYYY-MM-DD_change_brief.md
+```
+
+### Step 4 — Checkpoint (MANDATORY)
+
+**STOP.** Wait for Mariam to:
+- Answer open questions
+- Correct anything misread
+- Say "execute" (or equivalent confirmation)
+
+**Do NOT proceed without explicit confirmation.** If she modifies the brief, update it before executing.
+
+### Step 5 — Execute
+
+In one pass, batched in parallel where possible:
+
+- **Board updates** (status, dates) via GraphQL batched mutation
+- **Milestone updates** (rename, due_on, state) via REST API
+- **Issue moves** between milestones via REST API
+- **New issues** created via REST API with proper assignees + milestone, then added to project board + dates set
+- **Plan doc updated** — Edit in place. Do not append. Keep size stable.
+- **Cortex_Context.md updated** — Edit in place. Curate. Size budget < 10 KB.
+
+Use the field IDs and option IDs from prior sessions:
+- Project ID: `PVT_kwHOD3TEE84BSp-9`
+- Status field: `PVTSSF_lAHOD3TEE84BSp-9zhAIERg`
+  - Backlog: `f75ad846` | In Progress: `47fc9ee4` | In Review: `6fa38225` | Done: `98236657`
+- Start Date field: `PVTF_lAHOD3TEE84BSp-9zhAIPN4`
+- Target Date field: `PVTF_lAHOD3TEE84BSp-9zhAIPQA`
+
+### Step 6 — Report back
+
+Concise summary:
+- What changed (with issue/PR/milestone links)
+- What's outstanding for the week
+- New open items added to plan doc Section 4
+
+### Step 7 — Finalize audit trail in the repo
+
+Produce a polished public meeting record at:
+```
+docs/meetings/YYYY-MM-DD.md
+```
+(in the current worktree, NOT in main)
+
+This is the team-readable version. Lighter than the working draft — decisions, actions, what changed. No raw transcript.
+
+Stage, commit, and push:
+```bash
+git add docs/meetings/YYYY-MM-DD.md "Cortex_Release_Plan_*.md if also changed"
+git commit -m "docs: archive YYYY-MM-DD standup record"
+git push
+```
+
+If there is no existing PR for this worktree branch, open one. If there IS an existing PR, just push to it.
+
+**Do NOT auto-merge.** PRs need at least one human approval per repo policy.
+
+---
+
+## Rules
+
+- **NEVER skip the checkpoint** (Step 4). The workflow is worthless without it.
+- **NEVER make changes Mariam hasn't approved.**
+- **NEVER append to natural-language files.** Edit in place to keep size stable. If a file exceeds its budget, refactor.
+- **ALWAYS report Step 0 file sizes** before reading. Catches bloat early.
+- **ALWAYS query live board state from GitHub.** Don't trust file snapshots for what's currently true.
+- **NEVER touch other branches** — main, mariam/WIP-*, etc. Work only on the current worktree branch unless Mariam explicitly says otherwise.
+- **NEVER use `git add -A` or `git add .`** — stage by name only.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ![Version](https://img.shields.io/badge/version-1.1.0-blue)
 
+## 📋 Project Board
+
+Roadmap, releases, and team commitments are tracked on the **[Cortex Roadmap project board](https://github.com/users/mariamt-coder/projects/1)**.
+
+Every task, issue, and workstream lives there with a Start Date, Target Date, milestone, and owner. The board is the single forward-looking view of the project; this repo is the source of truth for the work itself.
+
 ## What is Value Consulting?
 
 Value Consulting is a disciplined practice that connects business outcomes to technology investments through evidence-based analysis. Unlike traditional consulting that focuses on deliverables or vendor solutions, Value Consulting focuses on **measurable business value creation**.

--- a/docs/meetings/2026-05-12.md
+++ b/docs/meetings/2026-05-12.md
@@ -1,0 +1,58 @@
+# Cortex Standup — 2026-05-12
+
+**Attendees:** Mariam, Mayur, Shobhit, Shyam, Anton
+**Format:** Team-readable summary. Working drafts and raw transcript live in PM folder.
+
+---
+
+## Decisions
+
+1. **3-week release cycle + quarterly majors** — replaces the original biweekly target. Sustainable cadence that matches team capacity.
+2. **Release order flipped:** Context graph operational ships first (Aug 8, internal), UI MVP second (Sep 12, full team).
+3. **Anton owns the UI MVP definition** — team commits to support his architectural decisions.
+4. **Release process roles formalized:**
+   - Mariam — drafts notes, sends announcements
+   - Mayur — approves significant changes
+   - Anton — architecture + Salesforce/integration
+   - Shyam — lead tester
+   - Shobhit's role (code-level readiness) to be confirmed separately
+5. **Release notes go out at 9 PM** in the Cortex Slack channel (avoids being buried).
+6. **Donna (mobile UI)** added to the roadmap as Release 4.0, target Dec 5.
+
+---
+
+## Action items
+
+| Owner | Action | Issue |
+|---|---|---|
+| Mariam | Update release plan + roadmap | done |
+| Mariam | Create sales leadership slides for Mayur | #58 |
+| Mariam | Develop critical thought partner | #48 |
+| Mariam | Collect team usage input → assign composable skills | #43 + follow-up |
+| Mariam | Define Donna v1 scope | #59 |
+| Mayur | Add Anton as repo admin | #25 |
+| Mayur | Migrate context graph from JSON to Postgres | #56 |
+| Anton | Define UI MVP scope + present for team agreement | #57 |
+| Anton | Schedule meeting with Mayur on UI MVP | (this week) |
+
+---
+
+## What changed as a result
+
+**New milestone:** Release 4.0 — Donna v1 (Dec 5)
+**Renamed milestones:** 2.0 (now Context graph), 3.0 (now UI MVP)
+**Closed milestone:** Release 2.1 (workshop recommender absorbed into 2.0)
+**Pushed:** Release 1.4 → Jul 25
+**Issues moved:** #41, #33 → Release 2.0; #22, #29, #30, #39, #40, #44, #51 → Release 3.0
+**Issues created:** #56, #57, #58, #59
+
+See [Cortex Roadmap project board](https://github.com/users/mariamt-coder/projects/1) for current state.
+
+---
+
+## Open / unresolved
+
+- Shobhit's release-process role — needs direct conversation
+- Domain Metrics Toolkit + APA process mining (Shobhit's tools) — not yet on the board
+- Shyam admin access to repo — Mayur to confirm
+- Anton's Salesforce work and Monish's GTM hosting (#51) — same workstream, owner-clarified

--- a/docs/meetings/2026-06-09.md
+++ b/docs/meetings/2026-06-09.md
@@ -1,0 +1,62 @@
+# Cortex Standup — 2026-06-09
+
+**Attendees:** Mariam, Mayur, Shyam
+**Format:** Team-readable summary. Working drafts and raw transcript live in PM folder.
+
+---
+
+## Decisions
+
+1. **Slide creation is the #1 user pain point.** Shyam to build a Claude Design integration + clean PPTX output pipeline. Target: **July 3** (Release 1.3).
+2. **#48 Critical thought partner scope expanded** to cover three behavior issues: sycophancy (original), drift (new), and forgetting iterations across sessions (new). #61 folded in.
+3. **Deal pricing / negotiation engine** stays in scope — make it wealth-agnostic, train on retail/commercial deals (Glacier, First Interstate, HNB), and add procurement "travel." Owner: Shyam. Target: end of July (Release 1.4).
+4. **API domain metrics integration stays with Shobhit.** Shyam stops forking. Rising API costs push us toward gtm.backbase.com infra over self-hosting.
+5. **Mariam owns market intelligence / first-level POV automation.** Bring Umaima's tool into Cortex. Adoption killer if we don't: Anik, Lauren, Isaak, Marwan all doing POVs in raw Claude. Target: July 3 (Release 1.3).
+6. **4 solution lines framework** is now standing: Digital Banking, Conversational Banking, Relationship Intelligence, Banking Operating System. Cortex value levers and POVs align here.
+7. **Two Backbase decks** (Conversational Banking + Unified Frontline May 2026) uploaded to Cortex by Mariam in Release 1.2.
+8. **share.backbase.com access** for the team — Anton's accountability. Shyam to chase.
+9. **Shyam's accidental upstream PR** — do NOT merge. Only the deal pricing piece comes in later, properly.
+10. **No phases.** "Phases are for humans. Agents don't need them." Build everything in scope.
+
+---
+
+## Action items
+
+| Owner | Action | Issue | Target |
+|---|---|---|---|
+| Shyam | Slide pipeline (Claude Design + PPTX) | #29, #30 | Jul 3 (R1.3) |
+| Shyam | Deal pricing/negotiation engine (wealth-agnostic + travel) | #64 | Jul 25 (R1.4) |
+| Shyam | Block calendar for focused slide work | — | this week |
+| Shyam | Ask Anton for share.backbase.com access | #68 | this week |
+| Mariam | Integrate Umaima's market intelligence tool | #65 | Jul 3 (R1.3) |
+| Mariam | Train Cortex on 4 solution lines | #66 | Jul 4 (R1.3) |
+| Mariam | Upload Conversational Banking + Unified Frontline May 2026 decks | #67 | Jun 13 (R1.2) |
+| Mariam | Continue #48 (now with drift + memory + POV vignettes) | #48 | R1.1 (held open) |
+| Mayur | Approve v1.2.0 release notes (still pending from May) | — | this week |
+| Mayur | Brief Mariam on PII / security hardening (still pending from May) | — | this week |
+| Shobhit | Continue API domain metrics + APA process mining (don't fork to Shyam) | — | ongoing |
+| Anton | Provision share.backbase.com access | #68 | this week |
+
+---
+
+## What changed as a result
+
+**New issues:** #64 (deal pricing engine), #65 (Umaima's tool), #66 (solution lines), #67 (knowledge decks), #68 (share.backbase.com access)
+**Issues reassigned:** #29, #30 → Shyam ownership, moved from Release 3.0 to Release 1.3
+**Issue scope expanded:** #48 (sycophancy → sycophancy + drift + memory + POV vignettes)
+**Issues closed:** #61 (folded into #48)
+**Milestones closed:** Stale pre-May 12 milestones #1, #2, #3, #4
+
+See [Cortex Roadmap project board](https://github.com/users/mariamt-coder/projects/1) for current state.
+
+---
+
+## Open / unresolved
+
+- v1.2.0 release notes — drafted May, still not sent (Mayur approval bottleneck)
+- Domain Metrics Toolkit + APA process mining — Shobhit's tools, still not on the board
+- Shyam admin access to repo — Mayur still hasn't confirmed
+- PII / security hardening (PR #37) — Mariam needs briefing from Mayur
+- NFCU ROI test — PR #36 sufficient or fresh run wanted?
+- Shobhit's release-process role — needs direct conversation
+- API cost trajectory — concrete trigger to accelerate #51 (reseller infra)?


### PR DESCRIPTION
## Summary
PM workflow scaffolding — two related additions that establish how Cortex coordination works going forward.

### 1. Project board pointer in README
Adds a **📋 Project Board** section near the top of the README linking to the [Cortex Roadmap project board](https://github.com/users/mariamt-coder/projects/1). GitHub doesn't allow linking user-owned projects natively into a different-owner repo, so this is the lightweight discoverable alternative.

### 2. `/process-meeting` slash command + finalized meeting records
Standardizes how Cortex weekly standup transcripts get processed into board updates, milestone changes, and doc edits.

Workflow:
- **Step 0:** Context-cost check (catches doc bloat early)
- **Step 1:** Ingest transcript, archive in PM folder
- **Step 2:** Read curated context (glossary + plan doc) + query live board state via GitHub API
- **Step 3:** Produce a structured Change Brief
- **Step 4 (mandatory):** Checkpoint with PM before any changes are made
- **Step 5:** Execute board + doc updates in batched parallel
- **Step 6:** Report back with audit trail
- **Step 7:** Archive finalized meeting record to `docs/meetings/`

### File organization
| Where | Purpose |
|---|---|
| PM folder (`Cortex PM/`) | Working drafts — raw transcript, change brief, plan doc, glossary |
| Repo (`docs/meetings/`) | Finalized public meeting records — team-readable audit trail |
| Repo (`.claude/commands/`) | The slash command itself |

Includes:
- `.claude/commands/process-meeting.md` — the slash command
- `docs/meetings/2026-05-12.md` — first finalized standup record
- `docs/meetings/2026-06-09.md` — Jun 9 standup record

### Note on scope

Banking OS knowledge base files were originally bundled in this PR but have been split out into a separate PR for cleaner review.

## Test plan
- [ ] README pointer renders correctly on GitHub and links to the board
- [ ] `/process-meeting` is discoverable in Claude Code (`/` autocomplete)
- [ ] `docs/meetings/2026-05-12.md` and `docs/meetings/2026-06-09.md` render cleanly as public records

🤖 Generated with [Claude Code](https://claude.com/claude-code)