### PR TITLE
fix: remove stray worktree gitlink + ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/
 
 # Claude Code local settings (agents and commands ARE tracked)
 .claude/settings.local.json
+.claude/worktrees/
 
 # Engagement data (client-confidential — never commit)
 engagements/


### PR DESCRIPTION
## Summary
- Removes `.claude/worktrees/recursing-lovelace` from the tree — it was tracked as a gitlink (mode 160000) with no matching `.gitmodules` entry, causing every fresh clone to show a phantom "missing submodule"
- Adds `.claude/worktrees/` to `.gitignore` so future Claude Code worktrees don't accidentally get committed

## Why this happened
Claude Code creates ephemeral git worktrees under `.claude/worktrees/` for isolated agent sessions. One of them got staged + committed as a gitlink. This PR is the fix + the guardrail against recurrence.

## Test plan
- [ ] After merge, `git status` on a fresh clone is clean (no "deleted submodule" noise)
- [ ] Creating a new Claude Code worktree no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)