### PR TITLE
add: auditability enforcement hooks (checkpoint + journal/telemetry gates)

### DIFF
--- a/.claude/hooks/enforce-journal.py
+++ b/.claude/hooks/enforce-journal.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Stop hook — the POST-completion auditability gate.
+
+Makes three "MANDATORY" governance rules from CLAUDE.md / auditability_protocol.md
+actually deterministic instead of advisory. Before the turn is allowed to end, for
+every engagement that produced a final deliverable in this session, this hook checks:
+
+  1. JOURNAL FRESHNESS  — a deliverable exists that is newer than the last
+                          ENGAGEMENT_JOURNAL.md update (i.e. work was not logged).
+  2. TELEMETRY BLOCK    — the journal contains at least one <!-- TELEMETRY_START -->.
+  3. DUAL CHECKPOINTS    — at least 2 checkpoints are logged (pre + post generation),
+                          counted as "### Checkpoint:" journal blocks + CHECKPOINT_*.md
+                          files in outputs/.
+
+If any rule is violated, the stop is BLOCKED and Claude is told exactly what to add.
+The fix (append the journal entry / log the checkpoint) is always within Claude's
+power, so the check is self-resolving and the loop terminates on the next stop.
+
+Scope: only engagements/*/*/ (real client work). tests/ and examples/ are exempt.
+Fail-OPEN: any internal error allows the stop — a buggy hook must never wedge a session.
+
+Decision contract (stdout JSON, exit 0):
+  - allow stop -> emit nothing
+  - block stop -> emit {"decision": "block", "reason": "..."}
+"""
+import glob
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", Path.cwd()))
+
+# Only deliverables this fresh count as "this session's work" worth enforcing.
+RECENCY_WINDOW_SECONDS = 12 * 3600
+# Grace so a deliverable written seconds before the journal append doesn't false-trip.
+JOURNAL_GRACE_SECONDS = 120
+
+DELIVERABLE_EXTS = {".md", ".html", ".xlsx", ".pptx", ".pdf", ".docx", ".csv"}
+TELEMETRY_MARKER = "<!-- TELEMETRY_START -->"
+
+
+def _allow():
+    sys.exit(0)
+
+
+def _block(reason: str):
+    print(json.dumps({"decision": "block", "reason": reason}))
+    sys.exit(0)
+
+
+def _is_deliverable(p: Path) -> bool:
+    if p.suffix.lower() not in DELIVERABLE_EXTS:
+        return False
+    name = p.name
+    if name.startswith((".", "interim_", "CHECKPOINT")):
+        return False
+    if name in {"ENGAGEMENT_JOURNAL.md", "ENGAGEMENT_CONTEXT.md", "CLIENT_PROFILE.md"}:
+        return False
+    return True
+
+
+def _newest_deliverable_mtime(outputs: Path):
+    newest = 0.0
+    if not outputs.is_dir():
+        return newest
+    for f in outputs.rglob("*"):
+        if f.is_file() and _is_deliverable(f):
+            try:
+                newest = max(newest, f.stat().st_mtime)
+            except OSError:
+                pass
+    return newest
+
+
+def _checkpoint_count(journal_text: str, outputs: Path) -> int:
+    count = journal_text.count("### Checkpoint:")
+    if outputs.is_dir():
+        count += len(list(outputs.glob("CHECKPOINT_*.md")))
+    return count
+
+
+def _audit_engagement(journal: Path):
+    """Return a (label, [findings]) tuple, or None if nothing to enforce."""
+    eng_dir = journal.parent
+    outputs = eng_dir / "outputs"
+    newest = _newest_deliverable_mtime(outputs)
+    if newest == 0.0:
+        return None  # no final deliverable produced yet — nothing to gate
+    if (time.time() - newest) > RECENCY_WINDOW_SECONDS:
+        return None  # stale engagement, not this session's work
+
+    try:
+        journal_text = journal.read_text(encoding="utf-8", errors="replace")
+        journal_mtime = journal.stat().st_mtime
+    except OSError:
+        return None
+
+    findings = []
+    if newest > journal_mtime + JOURNAL_GRACE_SECONDS:
+        findings.append(
+            "a deliverable was produced after the last journal update — append a "
+            "journal entry (agent, inputs, outputs, decisions) to ENGAGEMENT_JOURNAL.md"
+        )
+    if TELEMETRY_MARKER not in journal_text:
+        findings.append(
+            f"the journal has no telemetry block — add a {TELEMETRY_MARKER} … "
+            "<!-- TELEMETRY_END --> block (agent, session id, timings, file counts, "
+            "quality self-check)"
+        )
+    cp = _checkpoint_count(journal_text, outputs)
+    if cp < 2:
+        findings.append(
+            f"only {cp} consultant checkpoint(s) logged; the protocol requires 2 "
+            "(pre-generation + post-generation) — log them as '### Checkpoint:' entries"
+        )
+
+    if not findings:
+        return None
+    label = str(eng_dir.relative_to(PROJECT_DIR)) if str(eng_dir).startswith(str(PROJECT_DIR)) else str(eng_dir)
+    return (label, findings)
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+
+    # Avoid pathological loops: if we already blocked once this turn and Claude is
+    # continuing, still re-evaluate — the check is self-resolving, so a real fix clears it.
+    _ = payload.get("stop_hook_active", False)
+
+    try:
+        journals = glob.glob(str(PROJECT_DIR / "engagements" / "*" / "*" / "ENGAGEMENT_JOURNAL.md"))
+    except Exception:
+        _allow()
+
+    problems = []
+    for j in journals:
+        try:
+            result = _audit_engagement(Path(j))
+        except Exception:
+            result = None  # fail-open per engagement
+        if result:
+            problems.append(result)
+
+    if not problems:
+        _allow()
+
+    lines = [
+        "🛑 Auditability gate: an engagement produced deliverables without completing "
+        "its MANDATORY governance trail (CLAUDE.md → auditability_protocol.md). "
+        "Resolve before finishing:",
+        "",
+    ]
+    for label, findings in problems:
+        lines.append(f"• {label}")
+        for f in findings:
+            lines.append(f"    - {f}")
+    lines.append("")
+    lines.append(
+        "Append the missing journal/telemetry/checkpoint records, then stop. "
+        "(If this deliverable is genuinely interim/exploratory and not client work, "
+        "tell the user — do not silently bypass.)"
+    )
+    _block("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/require-checkpoint.py
+++ b/.claude/hooks/require-checkpoint.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook — the PRE-generation checkpoint gate.
+
+Enforces the "checkpoint BEFORE generation" half of the dual-checkpoint rule.
+Blocks writing a FINAL client deliverable into an engagement's outputs/ until a
+pre-generation checkpoint has been presented and logged. This is what makes
+"minimum 2 consultant checkpoints (pre + post)" deterministic instead of advisory:
+without this, an agent can generate the whole deliverable and only then (maybe)
+log a checkpoint — exactly the "agents make unilateral decisions" failure the
+NFIS retrospective flagged.
+
+A pre-generation checkpoint counts as satisfied if EITHER:
+  - a CHECKPOINT_*.md file exists in <engagement>/outputs/, OR
+  - ENGAGEMENT_JOURNAL.md contains a "### Checkpoint:" block.
+
+Scope (kept deliberately narrow to avoid false blocks):
+  - only Write (deliverable creation/overwrite), not Edit
+  - only paths under engagements/<client>/<engagement>/outputs/
+  - only deliverable file types; CHECKPOINT_*, interim_*, journal/context/dotfiles
+    are always allowed so the checkpoint itself can be written first.
+
+Fail-OPEN on parse/lookup errors — never wedge a session on a hook bug.
+
+Decision contract (stdout JSON, exit 0):
+  - allow -> emit nothing
+  - deny  -> emit {"hookSpecificOutput": {permissionDecision: "deny", ...}}
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", Path.cwd()))
+
+DELIVERABLE_EXTS = {".md", ".html", ".xlsx", ".pptx", ".pdf", ".docx", ".csv"}
+
+
+def _allow():
+    sys.exit(0)
+
+
+def _deny(reason: str):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def _is_final_deliverable(p: Path) -> bool:
+    if p.suffix.lower() not in DELIVERABLE_EXTS:
+        return False
+    name = p.name
+    if name.startswith((".", "interim_", "CHECKPOINT")):
+        return False
+    if name in {"ENGAGEMENT_JOURNAL.md", "ENGAGEMENT_CONTEXT.md", "CLIENT_PROFILE.md"}:
+        return False
+    parts = {part.lower() for part in p.parts}
+    # Only gate real client engagements, and only the outputs/ deliverable folder.
+    return "engagements" in parts and "outputs" in parts
+
+
+def _engagement_dir(p: Path):
+    # Deliverables live in <engagement>/outputs/...; the engagement root is the
+    # parent of the 'outputs' component. Anchor on that so a stray journal/context
+    # copy inside outputs/ can't shadow the real engagement root.
+    parts = p.parts
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i] == "outputs":
+            cand = Path(*parts[:i])
+            if (cand / "ENGAGEMENT_JOURNAL.md").exists() or (cand / "ENGAGEMENT_CONTEXT.md").exists():
+                return cand
+            break
+    # Fallback: nearest ancestor (other than outputs/) carrying engagement markers.
+    for parent in p.parents:
+        if parent.name in {"outputs", "inputs"}:
+            continue
+        if (parent / "ENGAGEMENT_JOURNAL.md").exists() or (parent / "ENGAGEMENT_CONTEXT.md").exists():
+            return parent
+    return None
+
+
+def _has_pre_generation_checkpoint(eng_dir: Path) -> bool:
+    outputs = eng_dir / "outputs"
+    if outputs.is_dir() and any(outputs.glob("CHECKPOINT_*.md")):
+        return True
+    journal = eng_dir / "ENGAGEMENT_JOURNAL.md"
+    if journal.exists():
+        try:
+            if "### Checkpoint:" in journal.read_text(encoding="utf-8", errors="replace"):
+                return True
+        except OSError:
+            return True  # can't read — fail open
+    return False
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+
+    if payload.get("tool_name") != "Write":
+        _allow()
+
+    raw = (payload.get("tool_input", {}) or {}).get("file_path")
+    if not raw:
+        _allow()
+
+    p = Path(raw)
+    if not p.is_absolute():
+        p = (PROJECT_DIR / p).resolve()
+
+    if not _is_final_deliverable(p):
+        _allow()
+
+    eng_dir = _engagement_dir(p)
+    if eng_dir is None:
+        _allow()  # not inside a recognised engagement — don't gate
+
+    if _has_pre_generation_checkpoint(eng_dir):
+        _allow()
+
+    label = eng_dir.relative_to(PROJECT_DIR) if str(eng_dir).startswith(str(PROJECT_DIR)) else eng_dir
+    _deny(
+        f"🛑 Checkpoint gate: about to write the final deliverable '{p.name}' for "
+        f"engagement '{label}', but no PRE-generation consultant checkpoint has been "
+        f"logged. The auditability protocol requires presenting your plan/assumptions "
+        f"to the consultant BEFORE generating.\n"
+        f"Do this first:\n"
+        f"  1. Present the pre-generation checkpoint (scope, assumptions, value levers) "
+        f"to the consultant, OR write outputs/CHECKPOINT_<stage>.md capturing it.\n"
+        f"  2. Log it as a '### Checkpoint:' entry in ENGAGEMENT_JOURNAL.md.\n"
+        f"Then re-issue this write. (The post-generation checkpoint is enforced "
+        f"separately at session end.)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,36 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/anonymize-guard.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/require-checkpoint.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-journal.py"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## What

Two hooks that make three of CLAUDE.md's "MANDATORY" governance rules **deterministic** instead of advisory:

| Hook | Event | Enforces |
|---|---|---|
| `require-checkpoint.py` | `PreToolUse` (Write) | Blocks writing a final deliverable into `engagements/*/outputs/` until a **pre-generation checkpoint** is logged |
| `enforce-journal.py` | `Stop` | Blocks turn-end when a fresh deliverable lacks a **journal entry**, **telemetry block**, or **2 consultant checkpoints** |

`settings.json` wires both alongside the existing `anonymize-guard` + `auto-branch` hooks.

## Why

Closes the NFIS-retro gap: *"no consultant checkpoints — agents make unilateral decisions."* Writing rules as MANDATORY in prose didn't make them happen — nothing checked. These hooks check, in the harness, regardless of entry point. Together they give true **dual-checkpoint** enforcement: pre (Write gate) + post (Stop gate).

## Design

- **Scoped to `engagements/`** — `tests/` and `examples/` exempt
- **Fail-open** on hook errors — a hook bug can never wedge a session (matches `auto-branch.sh`)
- **Recency-gated** (12h) so opening the repo for unrelated work doesn't re-flag old engagements
- **Self-resolving** — the fix is always "append the missing record," so the gate never loops

## Not included

`anonymize-guard.py` is untracked on `main` (pre-existing gap — settings.json already references it). Left out to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)