### PR TITLE
feat(harness): developer-only eval-key onboarding

### DIFF
--- a/.claude/hooks/require-harness.py
+++ b/.claude/hooks/require-harness.py
@@ -132,6 +132,8 @@ def main():
         f"'Eval Acceptance Criteria' section). The agent should do this automatically when a "
         f"change to a component is requested.\n"
         f"  2. Then bb-design → bb-tickets → bb-build (verify = evals) → bb-pr-review.\n"
+        f"First time developing here? Run `bash evals/setup_dev.sh` once to configure your "
+        f"eval keys (your own Anthropic key + the shared Langfuse keys) — developers only.\n"
         f"If you are intentionally working OUTSIDE a change cycle, create the marker "
         f"`.prd/ACTIVE_CHANGE` to acknowledge it. (Harness infra under .claude/skills/bb-*, "
         f".claude/hooks/, evals/, and .github/ is exempt.)"

--- a/.claude/skills/bb-prd/SKILL.md
+++ b/.claude/skills/bb-prd/SKILL.md
@@ -23,6 +23,28 @@ The PRD feeds into `/bb-design` for UX and solution design, which then feeds int
 
 Before anything else, clean up from previous modules and ensure the project is ready.
 
+### 0.0 Developer eval environment (MANDATORY — developers only)
+
+The bb-* lifecycle uses evals as its verify gate, and the LLM-judges need an Anthropic
+API key. This applies to **developers changing components** — never to people who only
+run agents to generate outputs (they never reach this skill).
+
+Check whether the developer's eval keys are configured:
+
+```bash
+grep -q '^ANTHROPIC_API_KEY=.' evals/.env 2>/dev/null && echo CONFIGURED || echo MISSING
+```
+
+If **MISSING**, STOP and prompt the developer before continuing:
+
+> "You're starting development on cortex components, which runs through the eval gate.
+> Run `bash evals/setup_dev.sh` once — it will prompt for **your own Anthropic API key**
+> (for the LLM-judges) and seed the **shared Langfuse eval keys** (from the team). This
+> is a one-time, developer-only setup; people who just run agents don't need it."
+
+Do not proceed with the PRD until either `evals/.env` has `ANTHROPIC_API_KEY` or the
+developer explicitly chooses to continue with judges skipped (deterministic checks only).
+
 ### 0.1 Previous plugin cleanup
 
 Check if previous workshop plugins are still installed and remove them. This handles two paths:

--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,6 +1,8 @@
 # Secrets — never commit Langfuse / Anthropic keys
 .env
 .env.local
+# team-distributed shared Langfuse eval keys (out-of-band, never committed)
+.env.shared
 
 # Local virtualenv
 .venv/

--- a/evals/README.md
+++ b/evals/README.md
@@ -25,6 +25,23 @@ evals/
     judge/                      # LLM-as-judge harness (Opus) + prompts/ + standards_snapshot/
 ```
 
+## Developer onboarding (one-time) — developers only
+
+If you're going to **change agents/skills/components**, configure your eval keys once:
+
+```bash
+bash evals/setup_dev.sh
+```
+
+It prompts for **your own Anthropic API key** (for the LLM-judges) and seeds the
+**shared Langfuse eval keys**. People who only *run* agents to generate outputs do
+**not** need this and are never prompted (it's wired into the `bb-prd` lifecycle and
+the `require-harness` hook — dev-only entry points).
+
+- **Anthropic key**: each developer brings their own (`console.anthropic.com`).
+- **Shared Langfuse keys**: distributed out-of-band as `evals/.env.shared` (gitignored)
+  — get it from the team; `setup_dev.sh` picks it up automatically. (Never committed.)
+
 ## Three altitudes
 
 1. **Component (unit)** — score an agent's direct output on a fixed input. Fast dev signal.

--- a/evals/setup_dev.sh
+++ b/evals/setup_dev.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Developer onboarding for the bb-* harness eval keys.
+#
+# WHO RUNS THIS: developers who change agents/skills/components (the people the
+# bb-* lifecycle + eval gate apply to). People who only RUN agents to generate
+# outputs do NOT need this and are never prompted.
+#
+# WHAT IT SETS (into evals/.env, gitignored):
+#   ANTHROPIC_API_KEY  -> the developer's OWN key (for the LLM-judges). Prompted.
+#   LANGFUSE_*         -> the SHARED eval-project keys. Seeded from (in order):
+#                         existing env vars, then evals/.env.shared (team-distributed,
+#                         gitignored), else prompted.
+#
+# Idempotent: re-running only fills what's missing. Never commits secrets.
+set -euo pipefail
+cd "$(dirname "$0")/.."          # repo root
+ENV="evals/.env"
+SHARED="evals/.env.shared"       # optional, gitignored, team-distributed
+touch "$ENV"; chmod 600 "$ENV"
+
+# set KEY=VALUE in $ENV (replace if present, append if missing); skip empty values
+put() { local k="$1" v="$2"; [ -z "$v" ] && return 0
+  if grep -q "^${k}=" "$ENV"; then
+    tmp=$(mktemp); grep -v "^${k}=" "$ENV" > "$tmp"; mv "$tmp" "$ENV"; fi
+  printf '%s=%s\n' "$k" "$v" >> "$ENV"; }
+have() { grep -q "^${1}=." "$ENV"; }
+from_shared() { [ -f "$SHARED" ] && grep "^${1}=" "$SHARED" | head -1 | cut -d= -f2- || true; }
+
+echo "== bb-* developer eval setup =="
+
+# --- Langfuse (shared eval project) ----------------------------------------
+put LANGFUSE_HOST "${LANGFUSE_HOST:-$(from_shared LANGFUSE_HOST)}"
+have LANGFUSE_HOST || put LANGFUSE_HOST "https://cloud.langfuse.com"   # EU default
+for k in LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY; do
+  if ! have "$k"; then
+    v="${!k:-$(from_shared "$k")}"
+    if [ -z "$v" ]; then
+      read -r -p "Shared $k (from the team — leave blank to skip Langfuse logging): " v
+    fi
+    put "$k" "$v"
+  fi
+done
+
+# --- Anthropic (the developer's OWN key, for the judges) -------------------
+if ! have ANTHROPIC_API_KEY; then
+  echo
+  echo "The LLM-judges (arc threading, conservative bias, ...) need YOUR OWN Anthropic API key."
+  echo "Get one at https://console.anthropic.com/settings/keys"
+  read -r -s -p "ANTHROPIC_API_KEY (input hidden, blank to skip judges): " ak; echo
+  put ANTHROPIC_API_KEY "$ak"
+fi
+
+echo
+echo "Wrote $ENV. Configured: $(grep -oE '^[A-Z_]+' "$ENV" | tr '\n' ' ')"
+echo "Install eval deps:  python3 -m pip install -r evals/requirements.txt langfuse anthropic"
+echo "Smoke test:         python3 evals/run_experiment.py --deck evals/goldens/deck_valid_min.html"
+have ANTHROPIC_API_KEY || echo "NOTE: no ANTHROPIC_API_KEY — judges will be skipped until you add one (re-run this script)."


### PR DESCRIPTION
Prompts developers (only — not output users) to add their own Anthropic API key and seeds the shared Langfuse eval keys when they start a component change.

## How it works
- **`evals/setup_dev.sh`** — one-time, idempotent. Prompts for the developer's **own Anthropic key** (LLM-judges); seeds the **shared Langfuse keys** from gitignored `evals/.env.shared` (team-distributed) / env vars / prompt. Never commits secrets.
- **`bb-prd` Phase 0.0** — developer eval-environment check; prompts `setup_dev.sh` before planning. Only developers reach `bb-prd`.
- **`require-harness` hook** — first component-edit message points to `setup_dev.sh`.
- **Output users unaffected** — they run agents/orchestrate, never hit these entry points.

## Secret handling
- `evals/.env` and `evals/.env.shared` are gitignored (fixed an inline-comment gitignore line that left `.env.shared` unignored).
- Shared Langfuse keys are distributed **out-of-band** via `evals/.env.shared`, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)