### PR TITLE
fix(evals): generative-agent guardrail — platform achievability

### DIFF
--- a/evals/rubrics/component/specifics.py
+++ b/evals/rubrics/component/specifics.py
@@ -368,6 +368,15 @@ JUDGES: dict[str, list[str]] = {
 # Faithfulness/integrity judges run as critical (hard-fail on real failure).
 CRITICAL_JUDGES: set[str] = {"faithful_extraction_no_invention"}
 
+# Per-judge frozen standard. Generative agents (use cases, synthesis) are graded for
+# PLATFORM ACHIEVABILITY, not transcript-faithfulness — grounded in the Backbase
+# platform snapshot (OOTB product directory + the buildable platform layers).
+JUDGE_SNAPSHOTS: dict[str, str] = {
+    "usecases_grounded_in_product_directory": "backbase-platform-frozen.md",
+    "synthesis_faithful_to_workshops": "backbase-platform-frozen.md",
+    "levers_grounded_in_evidence": "backbase-platform-frozen.md",
+}
+
 
 def _run_judges(agent_name: str, text: str, context: str | None = None) -> list[CheckResult]:
     """Run the agent's registered semantic judges (soft, except faithfulness).
@@ -386,7 +395,8 @@ def _run_judges(agent_name: str, text: str, context: str | None = None) -> list[
                       f"# OUTPUT (the agent's result)\n{text}")
         else:
             target = text
-        out.append(judge(name, target, threshold=0.8, critical=critical))
+        out.append(judge(name, target, threshold=0.8, critical=critical,
+                         snapshot=JUDGE_SNAPSHOTS.get(name)))
     return out
 
 

--- a/evals/rubrics/judge/prompts/synthesis_faithful_to_workshops.md
+++ b/evals/rubrics/judge/prompts/synthesis_faithful_to_workshops.md
@@ -1,24 +1,27 @@
 # Judge: synthesis faithful to workshops (ignite-workshop-synthesizer)
 
-You are given (or the artifact references) the workshop INPUTS and the OUTPUT synthesis —
-a hypothesis-validation matrix (Confirmed / Partially Confirmed / Not Confirmed / Needs
-More Data), use-case candidates, and a classification (Quick Wins / Foundational /
-Transformational / Defer). The failure mode is invented conclusions — declaring a
-hypothesis "Confirmed" or surfacing a use case the workshops did not actually support.
+The synthesis has two DIFFERENT kinds of content, judged by two DIFFERENT standards:
 
-Score 1.0 only if ALL hold:
-- **Faithful to inputs**: every validation status, use-case candidate, and conclusion
-  traces to what the workshops actually produced — nothing invented.
-- **Honest statuses**: a hypothesis is only "Confirmed" if the workshop input genuinely
-  supports it; weak/mixed signal is correctly marked Partially Confirmed or Needs More
-  Data, not upgraded.
-- **No fabricated use cases**: use-case candidates derive from workshop discussion, not
-  introduced fresh in synthesis.
-- **Classification justified**: Quick Win / Foundational / Transformational / Defer
-  assignments are reasoned from the inputs, not arbitrary.
+1. **FINDINGS — must be faithful to the workshop.** Hypothesis-validation statuses
+   (Confirmed / Partially / Not Confirmed / Needs More Data), pain points, goals, and
+   strategic decisions must trace to what the workshops actually produced. Inventing a
+   "Confirmed" the inputs don't support, or a pain/goal nobody raised, is a hard miss.
 
-Deduct sharply for: a "Confirmed" status the inputs don't support; a use case or
-conclusion absent from the workshops; over-claiming consensus; classification asserted
-with no basis.
+2. **USE CASES — generative, judged by PLATFORM ACHIEVABILITY, not workshop provenance.**
+   It is EXPECTED and GOOD for the synthesis to introduce use cases the client never named:
+   the agent reasons from pains/goals to what could solve them, the team takes these to the
+   client, gets feedback, and validates later. So do NOT require use cases to derive from
+   the workshop discussion. Instead require each proposed use case to be **achievable on the
+   Backbase platform** — OOTB or buildable on a named platform layer (reason against the
+   FROZEN platform snapshot).
 
-Return JSON: {"score", "pass" (>=0.8), "reason"} — list statuses or conclusions not supported by the workshop inputs.
+Score 1.0 only if: (a) every validation status / pain / goal is faithful to the workshop
+inputs (no upgraded or invented findings), AND (b) every proposed use case is platform-
+achievable and ties to a stated pain/goal, AND (c) Quick Win / Foundational / Transformational
+/ Defer classifications are reasoned.
+
+Deduct sharply for: a "Confirmed" the inputs don't support; an invented pain/goal/conclusion;
+a use case that is NOT achievable on the platform.
+Do NOT deduct for: net-new use cases not mentioned in the workshop — that is the intended value.
+
+Return JSON: {"score","pass" (>=0.8),"reason"} — separate any unfaithful FINDINGS from any non-achievable USE CASES.

--- a/evals/rubrics/judge/prompts/usecases_grounded_in_product_directory.md
+++ b/evals/rubrics/judge/prompts/usecases_grounded_in_product_directory.md
@@ -1,23 +1,27 @@
-# Judge: use cases grounded in the product directory (usecase-designer)
+# Judge: use cases achievable on the Backbase platform (usecase-designer)
 
-The artifact designs use cases (UC-### IDs), each meant to map to real Backbase product-
-directory capabilities (RB.x.x / WB.x.x) and to carry a build classification
-(OOTB / Config / Custom) and a priority tier. The failure mode is invented capability —
-mapping a use case to a product feature that doesn't exist, or mis-classifying custom
-work as out-of-the-box.
+Use cases are GENERATIVE — the agent derives them from the client's problem statements
+and goals and proposes what could solve them. They are NOT expected to come from the
+transcript, and a use case the client never raised is GOOD (clients often don't know what
+the platform can do; it gets validated with them later). Do NOT penalise a use case for
+being net-new.
 
-Score 1.0 only if ALL hold:
-- **Real product-directory mapping**: each use case maps to a plausible, real Backbase
-  product-directory capability (RB./WB. IDs) — not an invented or vague feature.
-- **Justified OOTB/Config/Custom classification**: the build classification is reasoned,
-  not asserted — OOTB claims are credible (the capability genuinely exists out of the
-  box), and genuinely bespoke work is honestly marked Config or Custom.
-- **No over-promising OOTB**: the failure of claiming "out of the box" for what is really
-  custom is penalized hard — it misleads the effort/cost picture.
-- **Priority tiers reasoned**: Tablestakes/Differentiating or P1/P2/P3 tiers reflect value
-  and fit, not arbitrary ranking.
+The real guardrail is **achievability on the Backbase platform** — reason each use case
+against the FROZEN platform snapshot. A use case is sound if it is either:
+- **OOTB** — delivered by a product line (Digital Onboarding / Lending / Banking / Engage /
+  Assist, Grand Central, Platform Identity), OR
+- **Buildable** — on a named platform layer: Flow Foundation (low-code journeys/forms/rules),
+  Orchestration (Process Studio workflows / Agent Studio agents / Banking Capabilities
+  microservices), Nexus (shared customer truth), Intelligence (models/SLMs), Sentinel
+  (authority for agentic actions).
 
-Deduct sharply for: a use case mapped to a non-existent or fabricated capability; custom
-work labelled OOTB; missing or arbitrary build classification; unjustified priority tiers.
+Score 1.0 only if EVERY use case (a) traces to a stated problem or goal, AND (b) is clearly
+achievable OOTB or names a plausible platform-layer build path, AND (c) its OOTB / Config /
+Custom classification is honest (custom work not mislabelled OOTB).
 
-Return JSON: {"score", "pass" (>=0.8), "reason"} — name use cases with fabricated mappings or mis-stated OOTB/Config/Custom classification.
+Deduct sharply for: use cases requiring capability OUTSIDE the platform (core replacement,
+hand-wavy "AI does it" with no layer it runs on); use cases with no link to a problem/goal;
+custom work claimed as OOTB.
+Do NOT deduct for: net-new use cases the client didn't mention — that is the point.
+
+Return JSON: {"score","pass" (>=0.8),"reason"} — for any unsound use case, name it and say which platform layer (if any) could actually deliver it, or why it is not achievable.

--- a/evals/rubrics/judge/standards_snapshot/backbase-platform-frozen.md
+++ b/evals/rubrics/judge/standards_snapshot/backbase-platform-frozen.md
@@ -1,0 +1,38 @@
+# FROZEN Backbase platform capability snapshot (judge guardrail) — 2026-06-24
+
+What a use case must be achievable WITH. Snapshot of `knowledge/backbase_platform_lexicon.md`
++ `knowledge/banking_os.md` + `knowledge/domains/product_directory_*.md`. Bump deliberately
+when the platform docs change. A use case is achievable if it is delivered **OOTB** by a
+product line OR **buildable** on a named platform layer — not if it requires capability the
+platform doesn't have.
+
+## OOTB product lines (Unified Banking Suite — four quadrants)
+- **Onboarding & Origination** — Digital Onboarding (guided application, doc upload/OCR, eIDV,
+  AML, decision engine, eSignature), Digital Lending (loan origination, credit decisioning).
+- **Digital Banking** — daily banking: accounts, payments, transfers, cash management, self-service.
+- **Engagement & Expansion** — Digital Engage (campaigns, next-best-action, offers, life-event triggers).
+- **Human Assist** — Digital Assist (RM/advisor workspace: leads, pipeline, case mgmt).
+- **Grand Central** — connectors to cores, CRMs, KYC/AML/credit-bureau vendors, registries.
+- **Platform Identity** — biometrics, FIDO2/passkeys, device registration.
+(Per-domain specifics: product_directory_{retail,sme,commercial,wealth,investing}.md)
+
+## Buildable platform layers (6-layer Banking OS Runtime + Sentinel)
+- **Flow Foundation** — low-code: Journey Orchestrator, Form Builder, Business Rules Engine
+  → configure new journeys / forms / rules.
+- **Orchestration** — Process Studio (workflows) + Agent Studio (AI agents/missions) +
+  Banking Capabilities (reusable microservices) → build new workflows, agents, services.
+- **Nexus (Semantic/truth layer)** — Banking Ontology + shared customer truth, decision trail
+  → build use cases needing a shared, queryable customer/decision view.
+- **Intelligence layer** — Model Registry, banking-optimized models/SLMs → AI/ML use cases.
+- **Sentinel (Authority)** — identity, policies, approvals, Decision Tokens → governs/authorizes
+  agentic actions (required to take AI from pilot to production).
+
+## How to judge achievability
+- ✅ achievable: maps to an OOTB product line, OR a clear build on a named layer
+  (e.g. "stalled-application nudge" = Flow Foundation rule + Digital Engage campaign;
+  "advisor lead routing" = Digital Assist + Orchestration; "fraud-pattern hold" =
+  Intelligence model + Sentinel authority).
+- ❌ NOT achievable: requires core-banking replacement, a capability outside these layers,
+  or hand-waves "AI will do it" with no layer it would actually run on.
+- Generative is GOOD: a use case the client never mentioned is fine — even expected — as
+  long as it is platform-achievable. Do NOT penalise use cases for being net-new.


### PR DESCRIPTION
Corrects the guardrail for generative agents (usecase-designer, synthesizer): use cases are judged by **achievability on the Backbase platform** (OOTB or buildable on a named layer, reasoned against a frozen platform snapshot), NOT by transcript-faithfulness. Net-new use cases the client never raised are not penalised; capability outside the platform is flagged. Synthesis judge split: findings faithful to workshop; use cases by achievability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)