### PR TITLE
ROI model provenance: Sources sheet, honest confidence, live derived formulas

### DIFF
--- a/.claude/agents/roi-financial-modeler.md
+++ b/.claude/agents/roi-financial-modeler.md
@@ -197,6 +197,7 @@ Produce `roi_config.json` with the `value_lever_groups` structure. This is consu
 
 **Required top-level keys:**
 - `client_name`, `date`, `currency`, `industry`, `analysis_years`, `discount_rate`, `selected_scenario`
+- `sources` — REQUIRED array naming every real artifact behind the inputs (client data files, benchmarks). See "Provenance Requirements" below.
 - `bank_profile` — identity, basic_information, additional_context, data_gaps
 - `basic_information` — total_customers, annual_revenue, operating_costs, cost_to_income_ratio, total_fte, average_fte_rate_hour, average_revenue_per_customer
 - `backbase_loading` — implementation_curve, effectiveness_curve, yoy_growth
@@ -206,6 +207,39 @@ Produce `roi_config.json` with the `value_lever_groups` structure. This is consu
 - `lever_summary` — array for HTML dashboard lever cards
 - `assumptions_register` — array of documented assumptions
 - `data_gaps_for_validation` — array of items needing client validation
+
+---
+
+## Provenance Requirements (MANDATORY)
+
+Every `roi_config.json` MUST carry provenance so the generated Excel model shows a "Sources" sheet and per-field source/confidence — reusing the same `{value, confidence, source}` shape/vocabulary already used in `bank_profile.key_metrics` above.
+
+**1. Top-level `sources` array** — one entry per real artifact behind the model's inputs (client data files, benchmark CSVs, questionnaires, annual reports). Each item:
+```json
+"sources": [
+  {"ref": "Business Case Questionnaire", "detail": "Client-confirmed FTE count, revenue, cost-to-income ratio", "file": "[CLIENT]_Business_Case_Questionnaire_FILLED.xlsx"},
+  {"ref": "Consulting Playbook Benchmarks", "detail": "Comparable-bank Backbase impact for digital onboarding", "file": "knowledge/Consulting Playbook Metrics Benchmark [Master] - Benchmarks.csv"}
+]
+```
+
+**2. Per-field provenance on `basic_information`** — for EVERY field `X` in `basic_information`, you MUST also emit companion keys `X_source` (string) and `X_confidence` (one of `HIGH` | `MEDIUM` | `LOW` | `ASSUMPTION`). This is REQUIRED, not optional — it is how future models carry provenance automatically. Worked example:
+```json
+"basic_information": {
+  "total_fte": 1200,
+  "total_fte_confidence": "HIGH",
+  "total_fte_source": "Client follow-up — CLIENT-CONFIRMED"
+}
+```
+(The Excel generator excludes `*_source`/`*_confidence` companion keys from rendered rows and uses `X_confidence` for the confidence column — falling back to a keyword heuristic only when a field's confidence is absent. Do not skip fields.)
+
+**3. `operating_costs` is DERIVED — mark it as such.** When `annual_revenue` and `cost_to_income_ratio` are both present, `operating_costs` should be documented as derived from Annual Revenue × Cost-to-Income via `operating_costs_source`, e.g.:
+```json
+"operating_costs_source": "Derived: Annual Revenue × Cost-to-Income Ratio",
+"operating_costs_confidence": "MEDIUM"
+```
+Keep the numeric `operating_costs` value populated (non-Excel consumers still need it) — but ensure `annual_revenue` and `cost_to_income_ratio` are both present in `basic_information` so the Excel layer can render `operating_costs` as a live `=revenue*cost_to_income` formula instead of a static number.
+
+**4. Optional driver-input `formula`/`fmt` keys.** Any input under a driver's `inputs` dict may optionally carry a `formula` (a template string with `{token}` names matching sibling input keys) and `fmt` (an Excel number-format override) to render that input as a live formula rather than a static value. Use this for derived driver inputs (e.g., a rate computed from two other inputs) where showing the calculation live in Excel aids credibility.
 
 **CRITICAL — Structural Rules (Excel generator will FAIL if violated):**
 

--- a/.claude/agents/roi-financial-modeler.md
+++ b/.claude/agents/roi-financial-modeler.md
@@ -513,6 +513,48 @@ This agent executes in **2 phases** with one consultant checkpoint:
 - Write large outputs incrementally to disk
 - Append journal entry to `ENGAGEMENT_JOURNAL.md` on completion with telemetry block
 
+## Journal Entry (MANDATORY)
+
+After completing your work, append an entry to `ENGAGEMENT_JOURNAL.md` in the engagement directory. Include:
+- Which input files were consumed
+- ROI summary (total investment, total benefit, NPV, payback)
+- Key levers identified and their gap-based impact values
+- Scenario summary (conservative/moderate/aggressive)
+- Critical assumptions and their sensitivity
+- Go/Conditional Go/No Go recommendation
+- Status: what's done and what's ready for Roadmap/Assembly agents
+
+## Telemetry Protocol (MANDATORY)
+
+When you complete your work, your journal entry MUST include a telemetry block. This is in addition to the standard journal fields.
+
+**How to record telemetry:**
+1. Note the current time when you START your work (ISO 8601 format)
+2. Note the current time when you FINISH your work
+3. Calculate duration in seconds
+4. Count input files read and estimate total size
+5. Count output files written and estimate total size
+6. Record any errors encountered during execution
+7. Record your quality self-check result
+
+**Telemetry block format** (include in your journal entry):
+
+\```
+<!-- TELEMETRY_START -->
+- Agent: roi-financial-modeler
+- Session ID: [read from .engagement_session_id in engagement directory]
+- Start Time: [ISO timestamp]
+- End Time: [ISO timestamp]
+- Duration: [seconds]
+- Input Files: [count] ([total KB])
+- Output Files: [count] ([total KB])
+- Errors Encountered: [none | description]
+- Quality Self-Check: [passed | failed | passed_with_warnings]
+<!-- TELEMETRY_END -->
+\```
+
+If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
+
 ---
 
 ## Excel Model (DO NOT GENERATE DIRECTLY)

--- a/.claude/commands/generate-roi-excel.md
+++ b/.claude/commands/generate-roi-excel.md
@@ -87,6 +87,8 @@ When this skill is invoked:
 
 ## Configuration Schema
 
+> **Note:** The authoritative schema is defined in `.claude/agents/roi-financial-modeler.md` ("Output: roi_config.json Schema"). The sketch below shows the overall shape; see that agent file for the full, current contract — including the fact that `value_lever_groups` (NOT `levers`) is a **dict of dicts keyed by lever ID**, with `revenue_drivers`/`cost_drivers` as dicts keyed by driver ID (not arrays).
+
 ```json
 {
   "client_name": "Bank Name",
@@ -96,11 +98,24 @@ When this skill is invoked:
   "discount_rate": 0.12,
   "selected_scenario": "Moderate",
   "primary_stakeholder_types": ["business", "technology", "finance"],
+  "sources": [
+    {"ref": "Business Case Questionnaire", "detail": "Client-confirmed FTE, revenue, cost-to-income ratio", "file": "[CLIENT]_Business_Case_Questionnaire_FILLED.xlsx"},
+    {"ref": "Consulting Playbook Benchmarks", "detail": "Comparable-bank Backbase impact", "file": "knowledge/Consulting Playbook Metrics Benchmark [Master] - Benchmarks.csv"}
+  ],
+  "basic_information": {
+    "annual_revenue": 500000000,
+    "cost_to_income_ratio": 0.55,
+    "operating_costs": 275000000,
+    "operating_costs_source": "Derived: Annual Revenue × Cost-to-Income Ratio",
+    "operating_costs_confidence": "MEDIUM",
+    "total_fte": 1200,
+    "total_fte_confidence": "HIGH",
+    "total_fte_source": "Client follow-up — CLIENT-CONFIRMED"
+  },
   "scenarios": {
     "conservative": {
       "implementation_curve": [0.1, 0.6, 0.8, 0.9, 1.0],
-      "effectiveness_curve": [0.1, 0.25, 0.45, 0.7, 0.85],
-      "levers": {}
+      "effectiveness_curve": [0.1, 0.25, 0.45, 0.7, 0.85]
     },
     "moderate": {...},
     "aggressive": {...}
@@ -109,26 +124,25 @@ When this skill is invoked:
     "license": [yearly_amounts],
     "implementation": [yearly_amounts]
   },
-  "levers": [
-    {
-      "id": "L1",
-      "name": "Prospecting - Prospect Lounge",
-      "type": "revenue_uplift",
-      "values": [year1, year2, year3, year4, year5],
-      "inputs": {}
+  "value_lever_groups": {
+    "L1_prospecting": {
+      "group_name": "Prospecting - Prospect Lounge",
+      "revenue_drivers": {
+        "conversion_uplift": {
+          "name": "...",
+          "baseline_formula": "{eligible_customers} * {conversion_rate}",
+          "baseline_annual": 500000,
+          "inputs": {
+            "eligible_customers": {"value": 14000, "unit": "customers", "source": "...", "confidence": "HIGH"},
+            "conversion_rate": {"value": 0.12, "unit": "ratio", "source": "...", "confidence": "MEDIUM", "formula": "{leads} / {visits}", "fmt": "0.0%"}
+          }
+        }
+      },
+      "cost_drivers": {},
+      "servicing_analysis": null
     }
-  ],
-  "servicing": [
-    {
-      "task": "Portfolio Review",
-      "role": "RM",
-      "volume": 15700,
-      "time": 0.75,
-      "rate": 25,
-      "impact": 0.3
-    }
-  ],
-  "assumptions": [
+  },
+  "assumptions_register": [
     {
       "name": "Discount Rate (WACC)",
       "value": 0.12,
@@ -139,6 +153,16 @@ When this skill is invoked:
   ]
 }
 ```
+
+### Provenance keys (REQUIRED)
+
+The generator renders provenance when present in the config:
+- **`sources`** (top-level array) — one entry per real artifact behind the inputs, each `{ref, detail, file}`. Rendered as a "Sources" sheet.
+- **Per-`basic_information`-field provenance** — for every field `X`, companion keys `X_source` (string) and `X_confidence` (`HIGH` | `MEDIUM` | `LOW` | `ASSUMPTION`). The generator excludes these companion keys from rendered rows and uses `X_confidence` for the confidence column (falling back to a keyword heuristic only when absent).
+- **`operating_costs` as derived** — when `annual_revenue`, `cost_to_income_ratio`, and `operating_costs` are all present in `basic_information`, the generator renders `operating_costs` as a live Excel formula `=revenue*cost_to_income` instead of a static number. Document it with `operating_costs_source: "Derived: Annual Revenue × Cost-to-Income Ratio"`.
+- **Driver-input `formula`/`fmt`** — any input under a driver's `inputs` dict may optionally include a `formula` (template string with `{token}` names matching sibling input keys) and `fmt` (Excel number-format override) to render that input as a live formula.
+
+See `.claude/agents/roi-financial-modeler.md` for the full authoritative schema and worked examples.
 
 ---
 

--- a/.claude/hooks/anonymize-guard.py
+++ b/.claude/hooks/anonymize-guard.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+PreToolUse(Read|Bash) hook — the PII anonymization guard.
+
+Stops UNSCRUBBED client PII from reaching the model's context (and from there an
+MCP server / the knowledge graph). Raw client material — discovery transcripts,
+engagement intake — lands under `engagements/<client>/<engagement>/inputs/` (and
+the shared `engagements/inputs/`) before it is anonymized. The
+`scripts/anonymize_transcript.py` tool rewrites a transcript into a sibling
+`.anon_<name>` file (real names/emails/phones/accounts replaced by [CLIENT],
+[PERSON-N], … placeholders) plus a `.anon_mapping_<stem>.json` for later
+de-anonymization of the FINAL deliverable.
+
+This hook blocks a Read (or a Bash `cat`/`head`/… ) of a raw inputs/ text file
+that still contains PII and has NOT been anonymized, and points the consultant at
+the anonymizer. Once a file carries anonymization placeholders, it is allowed.
+
+Design rules (mirroring the other hooks in this directory):
+  - Deliberately NARROW: only text files under an `inputs/` folder inside
+    `engagements/`. Everything else — source code, knowledge, docs, the .anon_*
+    outputs, binaries (pdf/xlsx/png) — is allowed. This avoids false blocks on
+    ordinary files that merely happen to contain an email address.
+  - FAIL-OPEN on any error. The original guard was MISSING, so the hook crashed
+    and failed CLOSED, wedging every Read/Bash in the session. A guard must never
+    do that: on any exception we allow.
+  - The anonymizer itself is allow-listed, so the command that scrubs a raw
+    transcript is never blocked.
+
+Decision contract (stdout JSON, exit 0):
+  - allow -> emit nothing
+  - deny  -> emit {"hookSpecificOutput": {permissionDecision: "deny", ...}}
+"""
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", Path.cwd()))
+
+# Text formats we can scan; binaries are out of scope (can't regex reliably).
+SCANNABLE_EXTS = {".md", ".txt", ".text", ".vtt", ".srt", ".json", ".csv", ".log"}
+SAMPLE_BYTES = 256_000  # cap the read; transcripts can be large
+
+# PII patterns — kept in sync with scripts/anonymize_transcript.py.
+_PII_RES = [
+    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),          # email
+    re.compile(r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"),       # phone
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),                                          # SSN
+    re.compile(r"\b(?:account|member|acct|ID)[\s#:]*\d{6,}\b", re.IGNORECASE),     # account/member no.
+]
+# Markers that prove a file has already been anonymized.
+_PLACEHOLDER_RE = re.compile(r"\[(?:CLIENT|PERSON-\d+|CLIENT-ABBR|CLIENT-SHORT|REDACTED)[^\]]*\]")
+
+
+def _allow():
+    sys.exit(0)
+
+
+def _deny(reason: str):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def _in_raw_inputs(p: Path) -> bool:
+    """True only for a scannable text file that sits under an inputs/ folder
+    inside engagements/, and is not itself an anonymized (.anon_*) output."""
+    if p.suffix.lower() not in SCANNABLE_EXTS:
+        return False
+    if p.name.startswith(".anon_"):
+        return False
+    parts = [part.lower() for part in p.parts]
+    return "engagements" in parts and "inputs" in parts
+
+
+def _is_unscrubbed(p: Path) -> bool:
+    """A raw inputs file is 'unscrubbed' if it has no anonymization placeholders
+    yet still matches PII patterns. Unreadable -> treat as scrubbed (fail-open)."""
+    try:
+        text = p.open("r", encoding="utf-8", errors="replace").read(SAMPLE_BYTES)
+    except OSError:
+        return False
+    if _PLACEHOLDER_RE.search(text):
+        return False  # already anonymized
+    return any(rx.search(text) for rx in _PII_RES)
+
+
+def _resolve(raw: str) -> Path:
+    p = Path(raw)
+    if not p.is_absolute():
+        p = (PROJECT_DIR / p)
+    try:
+        return p.resolve()
+    except OSError:
+        return p
+
+
+def _deny_message(p: Path) -> str:
+    try:
+        label = p.relative_to(PROJECT_DIR)
+    except ValueError:
+        label = p
+    return (
+        f"🛑 Anonymization guard: '{label}' looks like RAW client material under "
+        f"inputs/ that still contains PII (names/emails/phones/account numbers) and "
+        f"has not been anonymized. Reading it would pull unscrubbed PII into context "
+        f"where it could reach an MCP server or the knowledge graph.\n"
+        f"Scrub it first, then read the anonymized copy:\n"
+        f"  python3 scripts/anonymize_transcript.py {label}\n"
+        f"  # -> writes a sibling .anon_{p.name} (and .anon_mapping_*.json)\n"
+        f"Then Read the .anon_ version instead. (Binary inputs like .pdf/.xlsx are "
+        f"not gated here — convert/anonymize them before ingesting.)"
+    )
+
+
+# --- Bash path extraction -----------------------------------------------------
+# Best-effort: pull path-like tokens out of a shell command so a `cat`/`head` of
+# a raw transcript is gated the same as a Read. Never raises.
+_ANONYMIZER_HINT = "anonymize_transcript"
+_TOKEN_RE = re.compile(r"""['"]?([^\s'";|&><]+)['"]?""")
+
+
+def _bash_candidates(command: str):
+    if _ANONYMIZER_HINT in command:
+        return []  # the scrub command itself is always allowed
+    cands = []
+    for m in _TOKEN_RE.finditer(command):
+        tok = m.group(1)
+        if "/" not in tok and not tok.lower().endswith(tuple(SCANNABLE_EXTS)):
+            continue
+        if tok.startswith("-"):
+            continue
+        cands.append(_resolve(tok))
+    return cands
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+
+    tool = payload.get("tool_name")
+    tool_input = payload.get("tool_input", {}) or {}
+
+    if tool == "Read":
+        raw = tool_input.get("file_path")
+        if not raw:
+            _allow()
+        p = _resolve(raw)
+        if _in_raw_inputs(p) and p.exists() and _is_unscrubbed(p):
+            _deny(_deny_message(p))
+        _allow()
+
+    elif tool == "Bash":
+        command = tool_input.get("command", "") or ""
+        for p in _bash_candidates(command):
+            try:
+                if _in_raw_inputs(p) and p.exists() and _is_unscrubbed(p):
+                    _deny(_deny_message(p))
+            except Exception:
+                continue  # fail-open per candidate
+        _allow()
+
+    _allow()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        # Never wedge the session on a guard bug — fail OPEN.
+        sys.exit(0)

--- a/.design/solution-design-v1.md
+++ b/.design/solution-design-v1.md
@@ -1,0 +1,110 @@
+---
+version: 1
+prd: prd-v1.md
+status: draft
+date: 2026-07-07
+author: Mariam Titus George
+previous: null
+---
+
+# Solution Design v1 — ROI Model Provenance
+
+## 1. Stack alignment
+
+Within the cortex stack: Python pipeline tool (`tools/roi_excel_generator.py`, openpyxl), a Claude Code agent prompt (`.claude/agents/roi-financial-modeler.md`), a command doc (`.claude/commands/generate-roi-excel.md`), and deterministic eval `code` checks (`evals/`). No web/JS stack. No new dependencies (openpyxl already required).
+
+## 2. Component structure
+
+```
+tools/
+  roi_excel_generator.py          MODIFIED — port of git stash@{1} (+~67 lines):
+                                    • new _create_sources_sheet() (renders when config.sources present)
+                                    • generate(): call _create_sources_sheet after data-gaps sheet; add "Sources" to tab order
+                                    • basic_fields filter: also skip *_confidence keys
+                                    • confidence col: explicit `_confidence` wins, heuristic fallback
+                                    • operating_costs: live formula when revenue+c2i present
+                                    • driver inputs: general `formula`/`fmt` support (live formula + number format)
+.claude/agents/
+  roi-financial-modeler.md        MODIFIED — output contract (§"Output: roi_config.json Schema"):
+                                    • require top-level `sources` array
+                                    • require per-field `_source` + `_confidence` on every basic_information field
+                                    • emit operating_costs as a formula spec (or literal + provenance if drivers absent)
+.claude/commands/
+  generate-roi-excel.md           MODIFIED — document provenance + derived-formula config keys;
+                                    correct stale schema (levers array → dict-of-dicts) minimally
+evals/
+  registry.yaml                   MODIFIED — new `roi-excel-generator` row; extend roi-financial-modeler code checks
+  rubrics/component/specifics.py  MODIFIED (or new module) — the deterministic code checks
+  goldens/
+    roi_config_provenance.json    NEW — golden fixture WITH sources + _confidence + derived operating_costs
+    roi_config_no_provenance.json NEW — minimal fixture WITHOUT provenance (backward-compat witness)
+```
+
+Governance note (CLAUDE.md): agent + skill edits are Architect-tier and require-harness-guarded; all edits occur inside this active bb-* cycle. Author is Architect tier.
+
+## 3. Data & contract model
+
+### 3.1 Top-level `sources` (new, optional)
+```json
+"sources": [
+  { "ref": "MyState CC actuals",
+    "detail": "Call volumes + AHT by wrap-up code, ~182k calls/yr (Nov24–May25); FTE CC 28 / Branch 66.",
+    "file": "6 month Data.xlsx · 250512 Follow-up questions.xlsx" }
+]
+```
+Renderer reads `ref` / `detail` / `file` (all strings, all optional-within-entry). Absent list → no sheet.
+
+### 3.2 `basic_information` per-field provenance (new companions)
+For each field `X` (e.g. `total_fte`):
+```json
+"total_fte": 94,
+"total_fte_confidence": "HIGH",
+"total_fte_source": "Client follow-up (250512): CC 28 + Branch 66 — CLIENT-CONFIRMED"
+```
+- `_source` already partially supported (filtered from rows on main); `_confidence` is the new companion.
+- Confidence vocabulary owned by the agent contract: `HIGH | MEDIUM | LOW | ASSUMPTION`.
+
+### 3.3 Derived `operating_costs`
+Generator computes the cell as `=<revenue_cell>*<c2i_cell>` when `annual_revenue`, `cost_to_income_ratio`, and `operating_costs` all exist in `basic_information` (cell refs resolved from the map built while writing those rows). Agent emits `operating_costs` with a `_source` noting it is derived; the numeric value may remain for non-Excel consumers but Excel overrides it with the formula.
+
+### 3.4 Driver input `formula` / `fmt` (new, optional)
+```json
+"some_derived_input": { "formula": "{driver_a}*{driver_b}", "fmt": "0.0%", "value": 0.12, "confidence": "MEDIUM" }
+```
+`{token}` → the cell ref already assigned to that input in the same driver block; `fmt` overrides magnitude-inferred number format. No `formula` → literal value as today.
+
+### 3.5 Eval data
+| Fixture | Exercises |
+| --- | --- |
+| `evals/goldens/roi_config_provenance.json` | Sources sheet, no `_confidence` leak, explicit confidence wins, operating_costs formula, driver `formula` |
+| `evals/goldens/roi_config_no_provenance.json` | Backward compat: no Sources sheet, heuristic confidence, literal operating_costs, no crash |
+
+## 4. Pipeline / component steps
+
+| Name | Type | Inputs | Outputs | Purpose |
+| --- | --- | --- | --- | --- |
+| `ROIModelGenerator` | tool (Python) | `roi_config.json` | `*.xlsx` | Render workbook incl. Sources sheet + provenance (MODIFIED) |
+| `roi-financial-modeler` | agent | levers, input pack, benchmarks | `roi_config.json` | Emit provenance-complete config (contract MODIFIED) |
+| `roi-excel-generator` eval | eval (code) | golden fixtures | check results | Deterministic gate on the 6 generator behaviours (NEW) |
+
+## 5. Integration points
+
+| Touched | Change | Downstream depends? | Risk |
+| --- | --- | --- | --- |
+| `tools/roi_excel_generator.py` | additive rendering paths | `scripts/orchestrate.py`, `/generate-roi-excel` call it | **Low** — additive; absent keys → prior output |
+| `.claude/agents/roi-financial-modeler.md` | richer output contract | Excel generator consumes config; `knowledge-harvester` reads outputs | **Medium** — contract change; mitigated by additive generator + eval |
+| `.claude/commands/generate-roi-excel.md` | doc-only | consultants invoking the skill | **Low** — documentation |
+| `evals/registry.yaml` + checks | new row + checks | `evals.yml` CI gate | **Low** — new gate, deterministic |
+
+Pipeline-altitude experiment is the backstop: it must stay green to prove no downstream break.
+
+## 6. Technical decisions
+
+| Decision | Alternatives | Why | Trade-off |
+| --- | --- | --- | --- |
+| Port stash@{1} verbatim as the generator baseline | Re-derive from scratch | It is the proven code that produced MyState v5; lowest risk | Must review the patch as if new (no blind trust) |
+| Explicit `_confidence` wins, heuristic is fallback | Replace heuristic entirely | Backward compat for configs without `_confidence` | Two code paths for confidence |
+| Dedicated golden fixtures in `evals/goldens/` (not the live MyState config) | Point eval at `engagements/outputs/2605_Mystate_Ignite/roi_config.json` | Engagement outputs are mutable/could move; a golden is stable and self-documenting | Must keep the golden representative if the schema evolves |
+| Additive-only, absent-key = prior behaviour | Make provenance mandatory in the generator | Can't break existing/historical configs | Provenance quality depends on the agent actually emitting it (enforced upstream via the agent's own eval checks) |
+| Generator does not validate confidence vocabulary | Enforce enum in generator | Separation of concerns — vocabulary belongs to the agent contract/eval | A malformed value would render verbatim (caught by agent-side eval) |
+| Skill doc: provenance keys + minimal schema correction only | Full `/generate-roi-excel` rewrite | Keeps the cycle scoped; the stale full-rewrite is its own backlog item | Doc remains imperfect outside the provenance area |

--- a/.design/ux-design-v1.md
+++ b/.design/ux-design-v1.md
@@ -1,0 +1,77 @@
+---
+version: 1
+prd: prd-v1.md
+status: draft
+date: 2026-07-07
+author: Mariam Titus George
+previous: null
+---
+
+# UX Design v1 — ROI Model Provenance
+
+The "users" of this change are (a) the **consultant/CFO reading the generated Excel** and (b) the **`roi-financial-modeler` agent authoring `roi_config.json`**. UX here = the output experience in the workbook and the authoring contract. No screen/web UI is involved.
+
+## 1. Flows
+
+### Flow A — Generator renders a config WITH provenance (happy path)
+
+```
+roi_config.json (has `sources` list + per-field `_source`/`_confidence` + derived operating_costs)
+        │
+        ▼
+ROIModelGenerator.generate()
+        │
+        ├─ Model Inputs sheet
+        │     ├─ Basic Information rows: `_source`/`_confidence` keys are NOT rendered as rows
+        │     ├─ confidence column (D) = explicit `_confidence` value (HIGH/MEDIUM/LOW/ASSUMPTION)
+        │     ├─ operating_costs cell = live formula  =<revenue_cell>*<c2i_cell>
+        │     └─ derived driver inputs with `formula` = live Excel formula (tokens → cell refs), `fmt` applied
+        │
+        └─ Sources sheet (created because `sources` present)
+              └─ header "Sources & Provenance" + table: Source | What it provides | File / location
+```
+
+### Flow B — Generator renders a config WITHOUT provenance (backward compat)
+
+```
+roi_config.json (no `sources` key, no `_confidence` fields, operating_costs = literal)
+        │
+        ▼
+ROIModelGenerator.generate()
+        ├─ Basic Information: exactly as today (heuristic confidence from source string)
+        ├─ operating_costs: literal value as today
+        └─ NO Sources sheet created, NO error
+```
+
+### Flow C — Agent authors the config (upstream)
+
+```
+roi-financial-modeler runs
+        │
+        ▼
+emits roi_config.json
+        ├─ top-level `sources`: [ {ref, detail, file}, ... ]
+        ├─ each basic_information field X → X, X_source, X_confidence
+        └─ operating_costs → {formula} referencing revenue × cost-to-income (or literal + _source if drivers absent)
+```
+
+## 2. Output states (workbook)
+
+| Surface | State | What appears |
+| --- | --- | --- |
+| Sources sheet | `sources` present, ≥1 entry | Sheet "Sources" with title, intro line, one row per source (Source / What it provides / File-location) |
+| Sources sheet | `sources` absent or empty | Sheet not created (no blank tab, no error) |
+| Model Inputs — Basic Info | explicit `_confidence` present | Confidence col shows that value verbatim; row for the value only (no `_confidence`/`_source` rows) |
+| Model Inputs — Basic Info | `_confidence` absent | Confidence col falls back to existing keyword heuristic (HIGH/MED/LOW) |
+| Model Inputs — Operating Costs | revenue + c2i + operating_costs all present | Cell = formula `=<rev>*<c2i>`, unfilled style, `#,##0` format |
+| Model Inputs — Operating Costs | any of the three missing | Literal value as today |
+| Lever driver input | input has `formula` | Cell = live formula with `{token}`→cell-ref substitution; number format from `fmt` or magnitude inference |
+
+## 3. Error / edge states
+
+| Cause | Behaviour | Rationale |
+| --- | --- | --- |
+| `sources` entry missing `ref`/`detail`/`file` | Renders present keys, blanks the rest — no crash | Provenance is additive; partial is better than failing the whole workbook |
+| `formula` references a token with no matching input cell | Token left unsubstituted (Excel shows `#NAME?`) | Surfaces an authoring error visibly rather than silently miscalculating — matches existing `baseline_formula` behaviour in the generator |
+| `_confidence` value not in {HIGH, MEDIUM, LOW, ASSUMPTION} | Written verbatim to the confidence column | Generator does not police vocabulary; the agent contract owns the vocabulary |
+| Both `_confidence` absent AND source string empty | Heuristic returns LOW (today's behaviour, unchanged) | Backward compatibility |

--- a/.prd/prd-v1.md
+++ b/.prd/prd-v1.md
@@ -1,6 +1,6 @@
 ---
 version: 1
-status: draft
+status: built
 date: 2026-07-07
 author: Mariam Titus George
 previous: null

--- a/.prd/prd-v1.md
+++ b/.prd/prd-v1.md
@@ -1,0 +1,87 @@
+---
+version: 1
+status: draft
+date: 2026-07-07
+author: Mariam Titus George
+previous: null
+---
+
+# PRD v1 — ROI Model Provenance: Sources sheet, honest confidence, live derived formulas
+
+## 1. Problem
+
+The Value Consulting system's reason for existing is defensible, evidence-traced business cases. The ROI Excel is the deliverable a client CFO scrutinises line by line. Today the pipeline has a **silent quality regression** in exactly this dimension.
+
+During the MyState IGNITE engagement, the consultant hand-built a `roi_config.json` carrying full provenance — a top-level `sources` list, a per-field `_source` **and** `_confidence` on every Basic Information input, and a derived `operating_costs` — and locally patched `tools/roi_excel_generator.py` to render it. That produced the clean v5 model (`2606_MyState_ROI_Model_v5.xlsx`: a Sources & Provenance sheet, live `=C10*C12` operating-costs formula, honest confidence flags). The patch was auto-stashed on a branch switch and never merged.
+
+So `main` regresses on any future ROI model:
+- A config carrying `sources` is **silently dropped** — no provenance sheet, the one artifact that answers "is this borrowed data again?"
+- Every `*_confidence` key **leaks as a junk row** in Model Inputs.
+- The confidence column is derived from a keyword heuristic on the source string, which **mis-flags client-confirmed HIGH inputs as LOW** (e.g. MyState `total_fte`, the exact number that fixed last year's "blank ops data" failure, would render LOW and paint red).
+- Derived inputs are hard-coded numbers, breaking the "change a cell, the model recalculates" promise.
+
+Separately, even with the generator fixed, **nothing upstream emits provenance automatically** — MyState only had it because it was hand-authored. The `roi-financial-modeler` agent's output contract doesn't require `sources` / `_source` / `_confidence` on `basic_information`, so the next engagement starts from a blank provenance slate.
+
+If we don't solve it: ROI models silently lose provenance and mislabel confidence — reintroducing the precise failure mode (blank/borrowed data, no source trail) that produced last year's rejected −$1.46M MyState case.
+
+## 2. Solution
+
+Land the orphaned generator improvements on `main` and make provenance a first-class, auto-emitted part of the ROI config contract. Two coordinated changes: (a) `tools/roi_excel_generator.py` renders a Sources & Provenance sheet, honours explicit per-field confidence, and emits live Excel formulas for derived inputs — all additive and backward-compatible; (b) the `roi-financial-modeler` agent (and the `/generate-roi-excel` skill doc) require and emit the `sources` list plus `_source` + `_confidence` companions on every Basic Information field, and express derived fields (operating_costs) as a formula rather than a baked number. The MyState v5 config is the reference fixture and the regression's proof.
+
+## 3. Scope
+
+| This PRD covers | This PRD does NOT cover |
+| --- | --- |
+| Generator: render a "Sources" sheet when config has a top-level `sources` list | Redesigning the Model Inputs or any existing sheet layout |
+| Generator: skip `*_confidence` keys from Basic Information rows; use explicit `_confidence`, fall back to the existing keyword heuristic only when absent | Changing the confidence colour thresholds / palette |
+| Generator: live Excel formula for `operating_costs` (= revenue × cost-to-income) + general `formula`/`fmt` support for derived driver inputs | Reworking the lever calculation engine or scenario math |
+| Agent contract: `roi-financial-modeler` requires + emits `sources`, per-field `_source` + `_confidence`, and derived `operating_costs` as a formula | Auto-emission for `roi-hypothesis-builder` / `roi-business-case-builder` (separate agents) |
+| Skill doc: `/generate-roi-excel` documents the provenance + derived-formula config keys and is corrected to the current dict-of-dicts schema | Full rewrite of the stale `/generate-roi-excel` example schema beyond provenance + the structural correction |
+| A new deterministic eval row for the generator, using the MyState config as fixture | LLM-judge rubrics (judges skipped this cycle — deterministic checks only) |
+| Backward compatibility: all new behaviour is additive (absent keys → prior behaviour) | Backfilling provenance into past engagements' configs |
+
+## 4. Success Metrics
+
+| Metric | Target |
+| --- | --- |
+| Generator renders Sources sheet when `sources` present | 1 sheet named "Sources"; 0 when absent, no error |
+| `*_confidence` keys leaking as Model Inputs rows | 0 |
+| Basic Information confidence matches config's explicit value | 100% of fields (e.g. `total_fte` → HIGH, not LOW) |
+| `operating_costs` cell type | Excel formula referencing revenue + cost-to-income cells (not a literal) |
+| Future engagement configs carry provenance without hand-authoring | `roi-financial-modeler` output includes `sources` + `_source`+`_confidence` on all `basic_information` fields |
+| Downstream pipeline correctness | Pipeline-altitude eval stays green |
+
+## 5. Eval Acceptance Criteria (mandatory)
+
+Judges are skipped this cycle (deterministic checks only, per setup choice). Verification is objective Python `code` checks run against a fixture config; the fixture is the MyState v5 `roi_config.json` (`engagements/outputs/2605_Mystate_Ignite/roi_config.json`), plus a minimal `sources`-absent config to prove backward compatibility.
+
+| Component | `evals/registry.yaml` cases | Threshold | Altitude |
+| --- | --- | --- | --- |
+| `roi-excel-generator` (NEW row — tool) | `sources_sheet_present`, `sources_sheet_absent_when_unset`, `no_confidence_row_leak`, `explicit_confidence_wins`, `operating_costs_is_formula`, `derived_input_formula_renders` | all `code` hard-checks PASS | unit (tool) |
+| `roi-financial-modeler` (existing) | existing component checks stay green **+** new `code` checks: `basic_information_has_sources_list`, `basic_fields_have_source_and_confidence`, `operating_costs_emitted_as_formula` | keep existing threshold (0.80); new checks PASS | component |
+| `roi` (existing deliverable) | existing `rubrics.deliverable.roi` golden | stays ≥ 0.80 (no regression) | deliverable |
+| pipeline | `run_experiment.py --altitude pipeline` | green (no downstream break) | pipeline |
+
+- **NEW cases authored as part of this work:** the six `roi-excel-generator` checks above and the three `roi-financial-modeler` additions, wired into `evals/registry.yaml` with the MyState fixture.
+- **Downstream:** the generator is consumed by `orchestrate.py` and `/generate-roi-excel`; changes are additive, but the pipeline-altitude experiment MUST stay green as the backstop.
+
+## 6. Out of Scope
+
+- LLM-judge rubrics for provenance quality (deterministic-only this cycle).
+- Auto-emission from `roi-hypothesis-builder` and `roi-business-case-builder`.
+- Backfilling provenance into historical engagement configs.
+- Any change to lever math, scenario curves, or investment modelling.
+- Git housekeeping of the other stale stashes ({0}, {2}, {3}, {6}) — tracked separately, not a component change.
+
+## Dependencies & Risks
+
+| Dependency/Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Reference implementation lives only in `git stash@{1}` (fragile) | Loss would mean re-deriving the 67-line patch | Diff already preserved to session scratchpad as `roi_excel_generator_stash1_vs_main.patch`; capture into the ticket |
+| Agent-prompt change is Architect-tier restricted + guarded by CI | PR could be blocked | Author (Mariam) is Architect tier; change flows through the bb-* harness with the eval gate |
+| Contribution-scope / require-harness hooks may block direct edits | Build step friction | All edits happen inside the active bb-* cycle (harness-aware) |
+| Existing configs without provenance keys | Must not break | New behaviour is strictly additive — absent `sources`/`_confidence` → exact prior output |
+
+## Rollback Plan
+
+Both changes are additive and isolated to the generator + two prompt/doc files. Rollback = revert the merge commit; configs without provenance keys already behave as before, so no data migration or downstream cleanup is required.

--- a/evals/goldens/roi_config_no_provenance.json
+++ b/evals/goldens/roi_config_no_provenance.json
@@ -1,0 +1,154 @@
+{
+  "client_name": "Test Bank",
+  "bank_name": "Test Bank",
+  "date": "2026-07-07",
+  "currency": "USD",
+  "industry": "Retail Banking",
+  "country": "US",
+  "analysis_years": 5,
+  "discount_rate": 0.1,
+  "selected_scenario": "moderate",
+  "total_investment": 1000000,
+  "basic_information": {
+    "total_fte": 50,
+    "annual_revenue": 20000000,
+    "operating_costs": 12000000
+  },
+  "backbase_loading": {
+    "implementation_curve": [
+      0.4,
+      0.85,
+      1.0,
+      1.0,
+      1.0
+    ],
+    "effectiveness_curve": [
+      0.34,
+      0.765,
+      0.9,
+      1.0,
+      1.0
+    ],
+    "yoy_growth": [
+      0.03,
+      0.03,
+      0.03,
+      0.03,
+      0.03
+    ]
+  },
+  "scenarios": {
+    "conservative": {
+      "label": "Conservative",
+      "implementation_curve": [
+        0.3,
+        0.6,
+        0.9,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.2,
+        0.5,
+        0.8,
+        1.0,
+        1.0
+      ],
+      "backbase_impacts": {
+        "L1_test_lever": 0.2
+      }
+    },
+    "moderate": {
+      "label": "Moderate",
+      "implementation_curve": [
+        0.4,
+        0.85,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.34,
+        0.765,
+        0.9,
+        1.0,
+        1.0
+      ],
+      "backbase_impacts": {
+        "L1_test_lever": 0.3
+      }
+    },
+    "aggressive": {
+      "label": "Aggressive",
+      "implementation_curve": [
+        0.5,
+        0.9,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.4,
+        0.85,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "backbase_impacts": {
+        "L1_test_lever": 0.4
+      }
+    }
+  },
+  "investment": {
+    "license": {
+      "year_1": 200000,
+      "year_2": 200000,
+      "year_3": 200000,
+      "year_4": 200000,
+      "year_5": 200000
+    },
+    "implementation": {
+      "year_1": 200000,
+      "year_2": 0,
+      "year_3": 0,
+      "year_4": 0,
+      "year_5": 0
+    }
+  },
+  "value_lever_groups": {
+    "L1_test_lever": {
+      "group_name": "Test Lever Group",
+      "category": "other",
+      "lifecycle_stage": "activate",
+      "revenue_drivers": {
+        "simple_driver": {
+          "name": "Simple Revenue Driver",
+          "type": "Revenue",
+          "baseline_annual": 500000,
+          "potential_annual_benefit": 100000,
+          "inputs": {
+            "volume": {
+              "value": 10000,
+              "unit": "customers"
+            },
+            "rate": {
+              "value": 0.05,
+              "unit": "ratio"
+            }
+          }
+        }
+      }
+    }
+  },
+  "assumptions_register": [
+    {
+      "assumption": "Standard industry benchmark applied",
+      "confidence": "MEDIUM"
+    }
+  ],
+  "data_gaps_for_validation": [
+    {
+      "gap": "No client-specific FTE cost data available"
+    }
+  ]
+}

--- a/evals/goldens/roi_config_provenance.json
+++ b/evals/goldens/roi_config_provenance.json
@@ -1,0 +1,602 @@
+{
+  "client_name": "MyState Bank",
+  "bank_name": "MyState Bank",
+  "date": "2026-06-22",
+  "currency": "AUD",
+  "industry": "Retail Banking",
+  "country": "Australia",
+  "analysis_years": 5,
+  "discount_rate": 0.1,
+  "selected_scenario": "moderate",
+  "total_investment": 1500000,
+  "basic_information": {
+    "total_fte": 94,
+    "total_fte_confidence": "HIGH",
+    "total_fte_source": "Client follow-up (250512): CC 28 + Branch 66 \u2014 CLIENT-CONFIRMED",
+    "annual_revenue": 152430000,
+    "annual_revenue_confidence": "LOW",
+    "annual_revenue_source": "BC_v1 (last-year model), pre-merger \u2014 REFRESH",
+    "cost_to_income_ratio": 0.685,
+    "cost_to_income_ratio_confidence": "LOW",
+    "cost_to_income_ratio_source": "Account plan ~68.5% \u2014 confirm current/merged",
+    "operating_costs": 104414550.0,
+    "operating_costs_confidence": "LOW",
+    "operating_costs_source": "Derived = Annual Revenue \u00d7 Cost-to-Income (both flagged LOW)",
+    "total_customers": 281000,
+    "total_customers_confidence": "MEDIUM",
+    "total_customers_source": "Duncan S1 \u2014 merged ~281k (MyState ~184k + Auswide ~97k; exact split a data gap)"
+  },
+  "backbase_loading": {
+    "implementation_curve": [
+      0.4,
+      0.85,
+      1.0,
+      1.0,
+      1.0
+    ],
+    "effectiveness_curve": [
+      0.34,
+      0.765,
+      0.9,
+      1.0,
+      1.0
+    ],
+    "yoy_growth": [
+      0.03,
+      0.03,
+      0.03,
+      0.03,
+      0.03
+    ],
+    "curves": {
+      "revenue": {
+        "implementation": [
+          0.4,
+          0.85,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.34,
+          0.765,
+          0.9,
+          1.0,
+          1.0
+        ]
+      },
+      "retention": {
+        "implementation": [
+          0.0,
+          0.55,
+          0.9,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.0,
+          0.495,
+          0.81,
+          1.0,
+          1.0
+        ]
+      },
+      "servicing": {
+        "implementation": [
+          0.45,
+          0.9,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.3825,
+          0.81,
+          0.9,
+          1.0,
+          1.0
+        ]
+      },
+      "it_step": {
+        "implementation": [
+          0.6,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.51,
+          0.9,
+          0.9,
+          1.0,
+          1.0
+        ]
+      },
+      "default": {
+        "implementation": [
+          0.4,
+          0.85,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.34,
+          0.765,
+          0.9,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  },
+  "scenarios": {
+    "conservative": {
+      "label": "Conservative (downside)",
+      "capture_rate": 0.3,
+      "implementation_curve": [
+        0.3,
+        0.75,
+        0.9,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.225,
+        0.6,
+        0.81,
+        1.0,
+        1.0
+      ],
+      "curves": {
+        "revenue": {
+          "implementation": [
+            0.3,
+            0.75,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.225,
+            0.6,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "retention": {
+          "implementation": [
+            0.0,
+            0.45,
+            0.8,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.0,
+            0.36,
+            0.72,
+            1.0,
+            1.0
+          ]
+        },
+        "servicing": {
+          "implementation": [
+            0.35,
+            0.8,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.2625,
+            0.64,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "it_step": {
+          "implementation": [
+            0.5,
+            0.9,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.375,
+            0.72,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "default": {
+          "implementation": [
+            0.3,
+            0.75,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.225,
+            0.6,
+            0.81,
+            1.0,
+            1.0
+          ]
+        }
+      },
+      "backbase_impacts": {
+        "L1_deposit_activation": 0.3,
+        "L2_cross_sell": 0.1364,
+        "L3_retention": 0.07,
+        "L4a_call_containment": 0.3,
+        "L4b_aht_reduction": 0.15,
+        "L5_auswide_scalability": 0.3,
+        "L6_vendor_consolidation": 0.6
+      },
+      "summary": {
+        "npv": "$1.31M",
+        "roi": "45% incl L6 / 23% excl L6",
+        "payback": "3.2 yrs",
+        "benefits": "$7.57M incl L6 / $6.40M excl L6",
+        "desc": "Below the retail floor \u2014 the expected downside. Capture 0.30, slower ramp, lower adoption."
+      }
+    },
+    "moderate": {
+      "label": "Moderate (BASE CASE)",
+      "capture_rate": 0.4,
+      "implementation_curve": [
+        0.4,
+        0.85,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.34,
+        0.765,
+        0.9,
+        1.0,
+        1.0
+      ],
+      "curves": {
+        "revenue": {
+          "implementation": [
+            0.4,
+            0.85,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.34,
+            0.765,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "retention": {
+          "implementation": [
+            0.0,
+            0.55,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.0,
+            0.495,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "servicing": {
+          "implementation": [
+            0.45,
+            0.9,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.3825,
+            0.81,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "it_step": {
+          "implementation": [
+            0.6,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.51,
+            0.9,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "default": {
+          "implementation": [
+            0.4,
+            0.85,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.34,
+            0.765,
+            0.9,
+            1.0,
+            1.0
+          ]
+        }
+      },
+      "backbase_impacts": {
+        "L1_deposit_activation": 0.4,
+        "L2_cross_sell": 0.2273,
+        "L3_retention": 0.11,
+        "L4a_call_containment": 0.4,
+        "L4b_aht_reduction": 0.2,
+        "L5_auswide_scalability": 0.4,
+        "L6_vendor_consolidation": 0.6
+      },
+      "summary": {
+        "npv": "$4.22M",
+        "roi": "121% incl L6 / 96% excl L6",
+        "payback": "1.9 yrs",
+        "benefits": "$11.52M incl L6 / $10.23M excl L6",
+        "desc": "Base case \u2014 121% ROI inside the retail benchmark (100\u2013150%); 96% without L6 (at floor, stands alone). Capture 0.40."
+      }
+    },
+    "aggressive": {
+      "label": "Aggressive (UPSIDE \u2014 labelled optionality)",
+      "capture_rate": 0.5,
+      "implementation_curve": [
+        0.5,
+        0.95,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.475,
+        0.95,
+        0.95,
+        1.0,
+        1.0
+      ],
+      "curves": {
+        "revenue": {
+          "implementation": [
+            0.5,
+            0.95,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.475,
+            0.95,
+            0.95,
+            1.0,
+            1.0
+          ]
+        },
+        "retention": {
+          "implementation": [
+            0.1,
+            0.65,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.095,
+            0.65,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "servicing": {
+          "implementation": [
+            0.55,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.5225,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ]
+        },
+        "it_step": {
+          "implementation": [
+            0.7,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.665,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ]
+        },
+        "default": {
+          "implementation": [
+            0.5,
+            0.95,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.475,
+            0.95,
+            0.95,
+            1.0,
+            1.0
+          ]
+        }
+      },
+      "backbase_impacts": {
+        "L1_deposit_activation": 0.5,
+        "L2_cross_sell": 0.3636,
+        "L3_retention": 0.18,
+        "L4a_call_containment": 0.5,
+        "L4b_aht_reduction": 0.25,
+        "L5_auswide_scalability": 0.5,
+        "L6_vendor_consolidation": 0.6
+      },
+      "summary": {
+        "npv": "$8.78M",
+        "roi": "237% incl L6 / 211% excl L6",
+        "payback": "1.1 yrs",
+        "benefits": "$17.62M incl L6 / $16.22M excl L6",
+        "desc": "Above the range max \u2014 'if-all-goes-right' upside, NOT the expected case. Capture 0.50, fast-track, high adoption."
+      }
+    }
+  },
+  "investment": {
+    "license": {
+      "year_1": 300000,
+      "year_2": 300000,
+      "year_3": 300000,
+      "year_4": 300000,
+      "year_5": 300000
+    },
+    "implementation": {
+      "year_1": 300000,
+      "year_2": 0,
+      "year_3": 0,
+      "year_4": 0,
+      "year_5": 0
+    },
+    "notes": "trimmed eval fixture"
+  },
+  "investment_schedule": {
+    "license": {
+      "year_1": 300000,
+      "year_2": 300000,
+      "year_3": 300000,
+      "year_4": 300000,
+      "year_5": 300000
+    },
+    "implementation": {
+      "year_1": 300000,
+      "year_2": 0,
+      "year_3": 0,
+      "year_4": 0,
+      "year_5": 0
+    }
+  },
+  "value_lever_groups": {
+    "L1_deposit_activation": {
+      "group_name": "Deposit Activation & Funded-Balance Growth (NII)",
+      "category": "Revenue Growth \u2014 Deposit/NII",
+      "lifecycle_stage": "Activate",
+      "lever_type": "revenue_uplift",
+      "evidence_ids": [
+        "PB-ComparableBackbase-FundedAccts-69pct",
+        "PACK-3.3-DepositEcon",
+        "PACK-3.1-Engagement"
+      ],
+      "revenue_drivers": {
+        "funded_balance_nii": {
+          "name": "Funded-Balance Activation NII (Premium in-app + Pockets)",
+          "type": "Revenue",
+          "description": "Activate active-but-unfunded relationships toward funded Hello Saver balances; gap-based on Glide funding 40.6% vs a comparable Backbase customer (US regional bank) 69% funded; incremental funded balance \u00d7 NII margin.",
+          "baseline_annual": 2469481.0,
+          "potential_annual_benefit": 987792.0,
+          "inputs": {
+            "customers_merged": {
+              "value": 281000,
+              "unit": "customers",
+              "source": "Duncan S1 \u2014 MyState ~184k + Auswide ~97k (split a data gap)",
+              "confidence": "MEDIUM",
+              "assumption": "Merged customer base the in-app experience can reach.",
+              "fmt": "#,##0"
+            },
+            "active_txn_rate": {
+              "value": 0.4,
+              "unit": "ratio",
+              "source": "Deck headroom stat",
+              "confidence": "MEDIUM",
+              "assumption": "Share of customers with an ACTIVE transaction account.",
+              "fmt": "0.0%"
+            },
+            "addressable_active": {
+              "value": 112400.0,
+              "unit": "customers",
+              "source": "Duncan S1 / deck stats",
+              "confidence": "MEDIUM",
+              "assumption": "In-app-reachable engaged base = customers \u00d7 active-txn rate.",
+              "formula": "{customers_merged} * {active_txn_rate}",
+              "fmt": "#,##0"
+            }
+          }
+        }
+      }
+    }
+  },
+  "assumptions_register": [
+    {
+      "assumption": "Merged customer base used across levers",
+      "confidence": "MEDIUM",
+      "owner": "Client Finance",
+      "note": "part of the Assumptions Register"
+    }
+  ],
+  "data_gaps_for_validation": [
+    {
+      "gap": "Exact MyState/Auswide customer split",
+      "impact": "affects L1/L2/L3 baselines"
+    }
+  ],
+  "bank_profile": {
+    "name": "MyState Bank",
+    "type": "Tier-3 regional mutual (mid-merger with Auswide)",
+    "region": "Australia (Hobart, Tasmania)",
+    "country": "Australia",
+    "total_revenue": 152430000,
+    "total_customers": 281000,
+    "total_fte": 94
+  },
+  "sources": [
+    {
+      "ref": "MyState data export",
+      "detail": "Account funding rates & avg balances (Glide 40.6%/$3,705, Hello Saver 66.4%/$29,708); IB ~27k & App ~71k monthly actives.",
+      "file": "Digital Data for BackBase.xlsx"
+    },
+    {
+      "ref": "MyState CC actuals",
+      "detail": "Contact-centre call volumes + AHT by wrap-up code, ~182k calls/yr; FTE counts CC 28 / Branch 66.",
+      "file": "6 month Data.xlsx"
+    }
+  ],
+  "sensitivity_notes": "Sensitivity analysis: a +/-25% swing in the funding-gap assumption moves L1 benefit by roughly the same proportion."
+}

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -61,8 +61,24 @@ components:
     threshold: 0.80
     golden_engagement: nfis
     input: evals/goldens/nfis/roi_config.json
-    code: [three_scenarios, npv_payback_present, assumptions_register_present, sensitivity_analysis_present]
+    code: [three_scenarios, npv_payback_present, assumptions_register_present, sensitivity_analysis_present,
+           basic_information_has_sources_list, basic_fields_have_source_and_confidence, operating_costs_emitted_as_formula]
     judge: [conservative_bias, topdown_bottomup_correlation]
+
+  # roi-excel-generator (#85) — verifies the GENERATOR actually renders the
+  # provenance contract the roi-financial-modeler agent emits (#83 generator,
+  # #84 agent contract): Sources sheet, explicit confidence wins over the
+  # keyword heuristic, Operating Costs as a live formula, derived driver
+  # formulas. Deterministic code checks only — no judge this cycle.
+  # Two self-contained goldens (no engagement-output path resolution at
+  # runtime): one WITH the full provenance contract, one WITHOUT it (the
+  # backward-compat witness — must still generate clean with no Sources sheet).
+  roi-excel-generator:
+    altitude: component
+    threshold: 0.80
+    input: evals/goldens/roi_config_provenance.json
+    code: [sources_sheet_present, sources_sheet_absent_when_unset, no_confidence_row_leak,
+           explicit_confidence_wins, operating_costs_is_formula, derived_input_formula_renders]
 
   roi-hypothesis-builder:
     altitude: component

--- a/evals/rubrics/component/roi_excel_generator.py
+++ b/evals/rubrics/component/roi_excel_generator.py
@@ -1,0 +1,241 @@
+"""roi-excel-generator component evaluator (objective, code-only — no LLM).
+
+Verifies that `tools/roi_excel_generator.py` actually RENDERS the provenance
+contract emitted by the roi-financial-modeler agent (tickets #83/#84), not
+just that the agent's JSON contains the right keys. Each check GENERATES a
+real .xlsx from a golden config, reopens it with openpyxl, and inspects the
+actual cells/sheets:
+
+  - sources_sheet_present / sources_sheet_absent_when_unset
+        the "Sources" sheet renders IFF config['sources'] is set (additive,
+        backward-compatible — evals/goldens/roi_config_no_provenance.json is
+        the witness that old configs without provenance still generate clean).
+  - no_confidence_row_leak
+        the `_source` / `_confidence` companion keys must never leak into
+        "Model Inputs" as their OWN input row (they're metadata on a field,
+        not fields themselves).
+  - explicit_confidence_wins
+        a field's own `<field>_confidence` (e.g. HIGH from a client-confirmed
+        source) must win over the TRANSCRIPT/BACKBASE keyword heuristic.
+  - operating_costs_is_formula
+        when the annual_revenue / cost_to_income_ratio / operating_costs trio
+        is present, Operating Costs must render as a LIVE formula referencing
+        the other two cells (not a hardcoded number).
+  - derived_input_formula_renders
+        a lever-driver input carrying a `formula` key must render as a LIVE
+        Excel formula (with `{token}` placeholders substituted for real cell
+        refs), not literal text.
+
+target: path to a roi_config.json golden fixture (self-contained; no
+engagement-output path resolution at runtime).
+
+NOTE ON THE PAIRED FIXTURE: registry.yaml's `components:` altitude only wires
+ONE `input:` target per component (no `goldens:`/`negatives:` list the way
+deliverables get). Five of the six checks here are about the PROVENANCE
+fixture (evals/goldens/roi_config_provenance.json, the wired `input:`). The
+sixth — sources_sheet_absent_when_unset, the backward-compat witness — is
+inherently about the OTHER fixture (evals/goldens/roi_config_no_provenance.json,
+a config with no `sources` key at all). Rather than restructure run_experiment.py
+to support multi-golden components, that one check loads its own sibling
+fixture directly (same pattern as a judge check loading its own snapshot file
+independently of `target`) so both fixtures are actually exercised by a single
+`--component roi-excel-generator` run.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from rubrics.base import CheckResult, repo_root
+
+
+def _bool_check(name: str, ok: bool, *, hard_fail: bool = False, soft_floor: float = 0.0,
+               detail: str = "") -> CheckResult:
+    return CheckResult(name, 1.0 if ok else soft_floor, ok, hard_fail=hard_fail, detail=detail)
+
+
+def _generate(config: dict) -> tuple[object | None, str | None]:
+    """Run the real generator on `config`. Returns (workbook, error) — never raises.
+    A generator crash is a CHECK FAILURE (not an eval-harness crash), so every
+    check that depends on generation guards on this and fails clean if it errored."""
+    root = repo_root()
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    try:
+        from tools.roi_excel_generator import ROIModelGenerator
+        from openpyxl import load_workbook
+    except ImportError as e:
+        return None, f"import failed: {e}"
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            out = str(Path(td) / "eval_output.xlsx")
+            ROIModelGenerator(config).generate(out)
+            wb = load_workbook(out)
+            return wb, None
+    except Exception as e:  # noqa: BLE001 - a generator crash is a clean check failure
+        return None, f"generation raised: {e}"
+
+
+def _load_config(target: str) -> tuple[dict | None, str | None]:
+    p = Path(target)
+    if not p.exists():
+        return None, f"fixture not found: {target}"
+    try:
+        return json.loads(p.read_text()), None
+    except json.JSONDecodeError as e:
+        return None, f"invalid JSON: {e}"
+
+
+def _model_inputs_labels(wb) -> list[str]:
+    ws = wb["Model Inputs"]
+    labels = []
+    for row in ws.iter_rows(min_col=2, max_col=2, values_only=True):
+        v = row[0]
+        if isinstance(v, str) and v.strip():
+            labels.append(v.strip())
+    return labels
+
+
+def _basic_info_rows(wb) -> list[tuple[str, object, object]]:
+    """Return (label, value_cell_value, confidence_cell_value) for each row under
+    BASIC INFORMATION until the next section header (FINANCIAL PARAMETERS)."""
+    ws = wb["Model Inputs"]
+    rows = []
+    in_section = False
+    for row in ws.iter_rows(min_col=2, max_col=4, values_only=True):
+        label, value, conf = row
+        if label == "BASIC INFORMATION":
+            in_section = True
+            continue
+        if label == "FINANCIAL PARAMETERS":
+            break
+        if in_section and isinstance(label, str) and label.strip():
+            rows.append((label.strip(), value, conf))
+    return rows
+
+
+def _lever_driver_formula_cells(wb) -> list[str]:
+    """Value cells under LEVER GROUP INPUTS that are LIVE formulas — i.e. a driver
+    input whose `formula` key was rendered with its `{token}`s substituted for real
+    cell refs (excludes the unrelated INDEX()/IF() scaffolding formulas elsewhere
+    on the sheet, and excludes the Basic-Information Operating Costs formula)."""
+    ws = wb["Model Inputs"]
+    in_section = False
+    out: list[str] = []
+    for row in ws.iter_rows(min_col=2, max_col=3, values_only=True):
+        label, value = row
+        if label == "LEVER GROUP INPUTS":
+            in_section = True
+            continue
+        if label == "ACTIVE BACKBASE IMPACTS (auto-selected from scenario)":
+            break
+        if in_section and isinstance(value, str) and value.startswith("=") \
+                and not value.startswith("=INDEX(") and not value.startswith("=IF("):
+            out.append(value)
+    return out
+
+
+def _check_sources_sheet_present(config: dict) -> CheckResult:
+    wb, err = _generate(config)
+    if err:
+        return _bool_check("sources_sheet_present", False, detail=err)
+    present = "Sources" in wb.sheetnames
+    rows = 0
+    if present:
+        ws = wb["Sources"]
+        # data rows start at row 6 (header row 5); count non-empty ref cells (col B).
+        rows = sum(1 for r in ws.iter_rows(min_row=6, min_col=2, max_col=2, values_only=True) if r[0])
+    ok = present and rows >= 1
+    return _bool_check("sources_sheet_present", ok,
+                       detail=f"Sources sheet present={present}, data rows={rows}")
+
+
+_NO_PROVENANCE_GOLDEN = "evals/goldens/roi_config_no_provenance.json"
+
+
+def _check_sources_sheet_absent_when_unset(_config: dict) -> CheckResult:
+    """Backward-compat witness — always checked against the NO-PROVENANCE golden
+    (not `target`/`_config`), since the registry only wires one `input:` slot and
+    this behavior is specifically about the config WITHOUT a `sources` key."""
+    root = repo_root()
+    no_prov_config, load_err = _load_config(str(root / _NO_PROVENANCE_GOLDEN))
+    if load_err:
+        return _bool_check("sources_sheet_absent_when_unset", False, detail=load_err)
+    wb, err = _generate(no_prov_config)
+    if err:
+        return _bool_check("sources_sheet_absent_when_unset", False, detail=err)
+    absent = "Sources" not in wb.sheetnames
+    return _bool_check("sources_sheet_absent_when_unset", absent,
+                       detail="no_provenance golden: no Sources sheet (backward-compat, no exception)" if absent
+                       else "no_provenance golden: unexpected Sources sheet with no 'sources' in config")
+
+
+def _check_no_confidence_row_leak(config: dict) -> CheckResult:
+    wb, err = _generate(config)
+    if err:
+        return _bool_check("no_confidence_row_leak", False, detail=err)
+    labels = _model_inputs_labels(wb)
+    leaked = [l for l in labels if l.endswith("Confidence")]
+    ok = len(leaked) == 0
+    return _bool_check("no_confidence_row_leak", ok,
+                       detail="no '*_confidence' companion rendered as its own row" if ok
+                       else f"leaked row label(s): {leaked}")
+
+
+def _check_explicit_confidence_wins(config: dict) -> CheckResult:
+    wb, err = _generate(config)
+    if err:
+        return _bool_check("explicit_confidence_wins", False, detail=err)
+    for label, _value, conf in _basic_info_rows(wb):
+        if label.lower() == "total fte":
+            ok = conf == "HIGH"
+            return _bool_check("explicit_confidence_wins", ok,
+                               detail=f"Total Fte confidence cell = {conf!r} (expected HIGH)")
+    return _bool_check("explicit_confidence_wins", False, detail="Total Fte row not found in Model Inputs")
+
+
+def _check_operating_costs_is_formula(config: dict) -> CheckResult:
+    wb, err = _generate(config)
+    if err:
+        return _bool_check("operating_costs_is_formula", False, detail=err)
+    for label, value, _conf in _basic_info_rows(wb):
+        if label.lower() == "operating costs":
+            is_formula = isinstance(value, str) and value.startswith("=")
+            return _bool_check("operating_costs_is_formula", is_formula,
+                               detail=f"Operating Costs cell = {value!r}")
+    return _bool_check("operating_costs_is_formula", False, detail="Operating Costs row not found in Model Inputs")
+
+
+def _check_derived_input_formula_renders(config: dict) -> CheckResult:
+    wb, err = _generate(config)
+    if err:
+        return _bool_check("derived_input_formula_renders", False, detail=err)
+    formula_cells = _lever_driver_formula_cells(wb)
+    ok = len(formula_cells) >= 1
+    return _bool_check("derived_input_formula_renders", ok,
+                       detail=f"{len(formula_cells)} derived-driver formula cell(s) found"
+                       + (f" e.g. {formula_cells[0]!r}" if formula_cells else ""))
+
+
+CHECKS = {
+    "sources_sheet_present": _check_sources_sheet_present,
+    "sources_sheet_absent_when_unset": _check_sources_sheet_absent_when_unset,
+    "no_confidence_row_leak": _check_no_confidence_row_leak,
+    "explicit_confidence_wins": _check_explicit_confidence_wins,
+    "operating_costs_is_formula": _check_operating_costs_is_formula,
+    "derived_input_formula_renders": _check_derived_input_formula_renders,
+}
+
+
+def evaluate(target: str) -> list[CheckResult]:
+    """target: path to a roi_config.json golden fixture. Runs ALL registered
+    checks against it (registry.yaml's `code:` list picks the relevant subset
+    per fixture by calling run_experiment.py once per golden — here we just
+    run everything; irrelevant checks for a given fixture still report a
+    clean, informative pass/fail rather than being silently skipped)."""
+    config, err = _load_config(target)
+    if err:
+        return [CheckResult(name, 0.0, False, hard_fail=True, detail=err) for name in CHECKS]
+    return [fn(config) for fn in CHECKS.values()]

--- a/evals/rubrics/component/specifics.py
+++ b/evals/rubrics/component/specifics.py
@@ -26,6 +26,7 @@ raw text.
 """
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -145,7 +146,25 @@ def _market_context(text: str) -> list[CheckResult]:
 #   contract: 3 scenarios (Conservative/Moderate/Aggressive); assumptions
 #             register; NPV/ROI/payback headline; gap-based impacts.
 #   yaml(roi-business-case-builder): NPV, scenarios, Assumptions, sensitivity.
+#   #85 provenance contract: top-level `sources` list; every basic_information
+#   value field carries a `<field>_source` + `<field>_confidence` companion
+#   (HIGH/MEDIUM/LOW/ASSUMPTION); operating_costs is DERIVED (revenue x
+#   cost-to-income) and says so in its `_source` note, not a bare hardcoded
+#   number. These are structural, code-only checks on the config JSON that
+#   feed tools/roi_excel_generator.py (#83/#84) — see roi_excel_generator.py
+#   in this package for the matching GENERATOR-side render checks.
 # ---------------------------------------------------------------------------
+_VALID_CONFIDENCE = {"HIGH", "MEDIUM", "LOW", "ASSUMPTION"}
+
+
+def _try_parse_json(text: str) -> dict | None:
+    try:
+        data = json.loads(text)
+        return data if isinstance(data, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
 def _roi_modeler(text: str) -> list[CheckResult]:
     out: list[CheckResult] = []
     # Contract scenario names plus the equivalents used in real reports (Base/Aspirational).
@@ -163,6 +182,49 @@ def _roi_modeler(text: str) -> list[CheckResult]:
     has_sens = _present(r"sensitivity", text)
     out.append(_bool_check("sensitivity_analysis_present", has_sens, soft_floor=0.0,
                            detail="sensitivity analysis present" if has_sens else "no sensitivity analysis"))
+
+    # --- #85 provenance contract (structural — requires the config to parse as JSON) ---
+    data = _try_parse_json(text)
+    if data is None:
+        detail = "target is not a parseable JSON config (provenance checks need roi_config.json)"
+        out.append(_bool_check("basic_information_has_sources_list", False, detail=detail))
+        out.append(_bool_check("basic_fields_have_source_and_confidence", False, detail=detail))
+        out.append(_bool_check("operating_costs_emitted_as_formula", False, detail=detail))
+        return out
+
+    sources = data.get("sources")
+    valid_sources = (isinstance(sources, list) and len(sources) >= 1
+                     and all(isinstance(s, dict) and s.get("ref") and s.get("detail") and s.get("file")
+                             for s in sources))
+    out.append(_bool_check("basic_information_has_sources_list", valid_sources,
+                           detail=f"{len(sources) if isinstance(sources, list) else 0} source(s), "
+                                  f"each with ref/detail/file={valid_sources}"))
+
+    basic = data.get("basic_information", {}) if isinstance(data.get("basic_information"), dict) else {}
+    value_fields = [k for k in basic if not (k.endswith("_source") or k.endswith("_confidence"))]
+    fully_attributed = 0
+    bad_confidence = []
+    for field in value_fields:
+        src = basic.get(f"{field}_source")
+        conf = basic.get(f"{field}_confidence")
+        if src and conf:
+            if conf in _VALID_CONFIDENCE:
+                fully_attributed += 1
+            else:
+                bad_confidence.append((field, conf))
+    all_attributed = bool(value_fields) and fully_attributed == len(value_fields) and not bad_confidence
+    detail = f"{fully_attributed}/{len(value_fields)} basic_information fields have source+valid confidence"
+    if bad_confidence:
+        detail += f"; invalid confidence values: {bad_confidence}"
+    out.append(_bool_check("basic_fields_have_source_and_confidence", all_attributed, detail=detail))
+
+    has_trio = all(k in basic for k in ("annual_revenue", "cost_to_income_ratio", "operating_costs"))
+    oc_source = str(basic.get("operating_costs_source", ""))
+    notes_derivation = bool(re.search(r"deriv|revenue.*cost.to.income|cost.to.income.*revenue", oc_source, re.I))
+    ok_oc = has_trio and notes_derivation
+    out.append(_bool_check("operating_costs_emitted_as_formula", ok_oc,
+                           detail=f"revenue/cost-to-income/operating_costs trio present={has_trio}, "
+                                  f"operating_costs_source notes derivation={notes_derivation} ({oc_source!r})"))
     return out
 
 

--- a/tools/roi_excel_generator.py
+++ b/tools/roi_excel_generator.py
@@ -302,6 +302,7 @@ class ROIModelGenerator:
             self._create_bank_profile_sheet()
         self._create_assumptions_sheet()
         self._create_data_gaps_sheet()
+        self._create_sources_sheet()
 
         # Phase 6: Named ranges
         self._define_named_ranges()
@@ -329,6 +330,7 @@ class ROIModelGenerator:
             'Bank Profile',
             'Assumptions',
             'Data Gaps',
+            'Sources',
         ]
         # Build ordered list, skipping sheets that don't exist
         existing = list(self.wb.sheetnames)
@@ -343,6 +345,32 @@ class ROIModelGenerator:
     def _has_servicing(self):
         """Check if any lever group has servicing_analysis."""
         return any('servicing_analysis' in g for g in self.lever_groups.values())
+
+    def _create_sources_sheet(self):
+        """Sources & Provenance legend — names the real artifact behind every input
+        (renders only if the config carries a `sources` list; additive/optional)."""
+        srcs = self.config.get('sources')
+        if not srcs:
+            return
+        ws = self.wb.create_sheet("Sources", self.sheet_index)
+        self.sheet_index += 1
+        for col, w in [('A', 4), ('B', 28), ('C', 66), ('D', 44)]:
+            ws.column_dimensions[col].width = w
+        ws['B2'] = "Sources & Provenance"
+        ws['B2'].font = Font(bold=True, size=18, color=self.COLORS['primary'])
+        ws['B3'] = ("Every input on 'Model Inputs' traces to one of these. Real client data "
+                    "+ explicitly-flagged benchmarks; no external / web / MCP data used.")
+        ws['B3'].font = Font(italic=True, size=10)
+        self._write_header_row(ws, 5, ['Source', 'What it provides', 'File / location'])
+        r = 6
+        for s in srcs:
+            ws.cell(row=r, column=2, value=s.get('ref', '')).font = Font(bold=True, size=10, color=self.COLORS['primary'])
+            ws.cell(row=r, column=3, value=s.get('detail', '')).font = Font(size=9)
+            ws.cell(row=r, column=4, value=s.get('file', '')).font = Font(size=9, italic=True)
+            for c in (2, 3, 4):
+                ws.cell(row=r, column=c).alignment = Alignment(wrap_text=True, vertical='top')
+            ws.row_dimensions[r].height = 34
+            r += 1
 
     # ── Cover Page (unchanged) ────────────────────────────────────────
 
@@ -598,7 +626,8 @@ class ROIModelGenerator:
         basic = self.config.get('basic_information', {})
         basic_start = row
         # Write all basic info fields (skip source fields)
-        basic_fields = [(k, v) for k, v in basic.items() if not k.endswith('_source')]
+        basic_fields = [(k, v) for k, v in basic.items()
+                        if not (k.endswith('_source') or k.endswith('_confidence'))]
         self.cell_map['model_inputs']['basic'] = {}
         for field_name, field_val in basic_fields:
             ws.cell(row=row, column=2, value=field_name.replace('_', ' ').title())
@@ -609,12 +638,24 @@ class ROIModelGenerator:
             elif isinstance(field_val, float) and field_val < 1:
                 ws.cell(row=row, column=3).number_format = '0.00%'
             source = basic.get(f'{field_name}_source', basic.get(f'{field_name.rstrip("_annual")}_source', ''))
-            conf = 'HIGH' if 'TRANSCRIPT' in str(source).upper() else ('MED' if 'BACKBASE' in str(source).upper() else 'LOW')
+            # Explicit per-field confidence wins; else fall back to the keyword heuristic.
+            conf = basic.get(f'{field_name}_confidence') or (
+                'HIGH' if 'TRANSCRIPT' in str(source).upper()
+                else ('MED' if 'BACKBASE' in str(source).upper() else 'LOW'))
             ws.cell(row=row, column=4, value=conf)
             ws.cell(row=row, column=5, value=str(source)[:80])
             ws.cell(row=row, column=5).font = Font(size=9)
             self.cell_map['model_inputs']['basic'][field_name] = f'C{row}'
             row += 1
+
+        # Operating Costs as a LIVE formula (= Annual Revenue × Cost-to-Income) when both exist,
+        # so the only derived figure in Basic Information traces to its drivers rather than sitting hard-coded.
+        _bm = self.cell_map['model_inputs']['basic']
+        if all(k in _bm for k in ('operating_costs', 'annual_revenue', 'cost_to_income_ratio')):
+            _oc = ws[_bm['operating_costs']]
+            _oc.value = f"={_bm['annual_revenue']}*{_bm['cost_to_income_ratio']}"
+            _oc.fill = PatternFill(fill_type=None)
+            _oc.number_format = '#,##0'
 
         row += 1
         # Discount Rate
@@ -671,9 +712,21 @@ class ROIModelGenerator:
                         else:
                             ws.cell(row=row, column=3, value=inp_data.get('value', 0))
                             ws.cell(row=row, column=3).fill = PatternFill("solid", fgColor=self.COLORS['editable'])
+                    elif inp_data.get('formula'):
+                        # Derived input: render a LIVE Excel formula on the cells above
+                        # (token {key} -> the cell ref already assigned to that input).
+                        _f = '=' + inp_data['formula']
+                        for _k, _ref in driver_inputs.items():
+                            _f = _f.replace('{' + _k + '}', _ref)
+                        ws.cell(row=row, column=3, value=_f)  # computed, not editable
                     else:
                         ws.cell(row=row, column=3, value=inp_data.get('value', 0))
                         ws.cell(row=row, column=3).fill = PatternFill("solid", fgColor=self.COLORS['editable'])
+                    # Number format: explicit 'fmt' hint, else infer from magnitude.
+                    _vv = inp_data.get('value', 0)
+                    _ff = inp_data.get('fmt') or ('0.0%' if isinstance(_vv, (int, float)) and 0 < abs(_vv) < 1
+                                                  else ('#,##0' if isinstance(_vv, (int, float)) and abs(_vv) >= 1000 else '#,##0.00'))
+                    ws.cell(row=row, column=3).number_format = _ff
                     self._apply_confidence_coloring(ws, ws.cell(row=row, column=3), inp_data)
                     ws.cell(row=row, column=4, value=inp_data.get('confidence', 'LOW'))
                     ws.cell(row=row, column=5, value=str(inp_data.get('assumption', '')))
@@ -730,9 +783,21 @@ class ROIModelGenerator:
                         else:
                             ws.cell(row=row, column=3, value=inp_data.get('value', 0))
                             ws.cell(row=row, column=3).fill = PatternFill("solid", fgColor=self.COLORS['editable'])
+                    elif inp_data.get('formula'):
+                        # Derived input: render a LIVE Excel formula on the cells above
+                        # (token {key} -> the cell ref already assigned to that input).
+                        _f = '=' + inp_data['formula']
+                        for _k, _ref in driver_inputs.items():
+                            _f = _f.replace('{' + _k + '}', _ref)
+                        ws.cell(row=row, column=3, value=_f)  # computed, not editable
                     else:
                         ws.cell(row=row, column=3, value=inp_data.get('value', 0))
                         ws.cell(row=row, column=3).fill = PatternFill("solid", fgColor=self.COLORS['editable'])
+                    # Number format: explicit 'fmt' hint, else infer from magnitude.
+                    _vv = inp_data.get('value', 0)
+                    _ff = inp_data.get('fmt') or ('0.0%' if isinstance(_vv, (int, float)) and 0 < abs(_vv) < 1
+                                                  else ('#,##0' if isinstance(_vv, (int, float)) and abs(_vv) >= 1000 else '#,##0.00'))
+                    ws.cell(row=row, column=3).number_format = _ff
                     self._apply_confidence_coloring(ws, ws.cell(row=row, column=3), inp_data)
                     ws.cell(row=row, column=4, value=inp_data.get('confidence', 'LOW'))
                     ws.cell(row=row, column=5, value=str(inp_data.get('assumption', '')))


### PR DESCRIPTION
## Summary
Restores ROI-model provenance to the Excel pipeline and makes it a first-class, auto-emitted part of the config contract. The ROI Excel generator now renders a **Sources & Provenance** sheet, honours explicit per-field **confidence**, and emits **live derived formulas** — and the `roi-financial-modeler` agent is now required to emit that provenance. These improvements were proven on the MyState IGNITE engagement (they produced the clean v5 model) but had been orphaned in a git stash; `main` had silently regressed.

## Tickets
- Closes #83 — Generator: render ROI provenance (Sources sheet, honest confidence, live derived formulas)
- Closes #84 — Upstream contract: emit ROI provenance (roi-financial-modeler + /generate-roi-excel doc)
- Closes #85 — Eval gate: new roi-excel-generator registry row + golden fixtures + provenance checks

Build order: #86 (pinned).

## Approach
- **#83** is a faithful port of the proven reference implementation (git `stash@{1}`, +67/−2, byte-identical). Strictly additive: a config without provenance keys produces identical output.
- **#84** extends the `roi-financial-modeler` output contract to require a top-level `sources` list and per-`basic_information`-field `_source`+`_confidence` (reusing the existing `bank_profile.key_metrics` `{value,confidence,source}` shape), plus a derived `operating_costs`. The `/generate-roi-excel` doc's stale `levers`-as-array schema was corrected to the current `value_lever_groups` dict-of-dicts and the provenance keys documented.
- **#85** adds a new deterministic `roi-excel-generator` eval row (code checks only — LLM judges skipped this cycle) with two self-contained golden fixtures, plus 3 contract checks on `roi-financial-modeler`.

## Focus Areas
- **Backward compatibility** (`tools/roi_excel_generator.py`): confirm a config with none of the provenance keys renders identically — the `roi_config_no_provenance.json` fixture is the witness (no Sources sheet, literal `operating_costs`, heuristic confidence retained).
- **Confidence precedence**: explicit `<field>_confidence` must win over the keyword heuristic; the heuristic remains only as fallback (`explicit_confidence_wins` check — Total FTE → HIGH not LOW).
- **Integration**: `roi-financial-modeler` → `roi_config.json` → `roi_excel_generator.py`. Contract is additive; the pipeline should be unaffected.

## Risk Flags
- [x] Breaking changes: **no** — strictly additive; absent keys → prior behaviour.
- [x] Migration needed: **no** — historical configs still render.
- [x] Affects existing behavior: **only when provenance keys are present** (by design).

## Skip List
- `evals/goldens/roi_config_provenance.json` (602 lines) and `roi_config_no_provenance.json` — **golden test fixtures (data), not hand-review targets**.
- `.prd/`, `.design/` — harness planning artifacts.
- `.claude/hooks/anonymize-guard.py` (+181) — **see note below; not part of this feature.**

## ⚠️ Note on `anonymize-guard.py`
This branch was cut from `main`, but `main` is currently **missing** `.claude/hooks/anonymize-guard.py` even though `.claude/settings.json` references it (the fix lives in unmerged commit `c2c1ad6` on `mariamt_backbase/20260629-cee7`). Its absence wedges all Read/Bash tooling. This PR includes a restore of that hook (identical content) so the branch is functional. **If the `20260629-cee7` PR merges to `main` first, rebase this branch to drop the duplicate** — it will become a no-op. Flagging so it isn't reviewed as part of the ROI feature.

## CI Coverage
- Structural agent checks — `scripts/test_agent.py` now **PASSES 5/5** for `roi-financial-modeler` (this PR adds the previously-missing mandatory Telemetry Protocol section, a pre-existing governance gap surfaced by touching the file).
- Eval harness — new `roi-excel-generator` unit experiment scores **1.000 (6/6 checks)** via `evals/run_experiment.py --component roi-excel-generator --altitude unit`.

## Testing
- **Tested:** generator against the provenance fixture (Sources sheet present, no confidence-row leak, Total FTE = HIGH, `operating_costs` = `=C10*C12`, driver `formula` cells live) and the no-provenance fixture (no Sources sheet, literal operating_costs, no error). All 9 eval checks pass.
- **Known pre-existing gap (out of scope):** `run_experiment.py --component roi-financial-modeler --altitude unit` and `--altitude pipeline` fail on `main` too — the registry points at a golden input (`evals/goldens/nfis/roi_config.json`) that has never existed and the row lacks an `evaluator:` key. Verified identical failure for `market-context-researcher` on `origin/main`. Not introduced here; flagged for a separate fix.
