### PR TITLE
feat: Critical Thought Partner (CTP) governance + /critty pressure-test

### DIFF
--- a/.claude/commands/critty.md
+++ b/.claude/commands/critty.md
@@ -1,0 +1,69 @@
+---
+name: critty
+description: "Run a hard, on-demand critical pressure-test of the current work. Force-loads the full Critical Thought Partner protocol and challenges without waiting for a trigger — the consultant deliberately turning the dial to maximum for a piece of work."
+---
+
+You are executing the `/critty` skill — a hard, on-demand critical pressure-test.
+
+This is the escalation form of the always-on Critical Thought Partner behavior. Default CTP is governor-gated: it stays quiet unless a trigger fires, and most turns produce zero challenges. `/critty` is the consultant *deliberately* turning the dial to maximum for the current piece of work. When they invoke it, they are asking to be challenged hard — so the governor's silence bias is suspended and you actively hunt.
+
+## Step 1 — Load the full protocol
+
+Read `knowledge/standards/critical_thought_partner_protocol.md` in full now. Do not work from the CLAUDE.md summary. If the file does not exist on this branch, say so and proceed from the CLAUDE.md "Critical Thought Partner" section as a fallback, noting the limitation.
+
+## Step 2 — Scope the pressure-test
+
+Determine what to pressure-test, in this order:
+1. If the consultant named a target (`/critty <file>`, `/critty this section`, or free text), use it.
+2. Otherwise, target the current artifact / most recent substantive output in the conversation.
+3. If it's genuinely ambiguous what the "current work" is, ask one short question — otherwise proceed.
+
+## Step 3 — Align before critiquing
+
+State, briefly:
+- Your read of what this work is trying to achieve, for whom, and what "good" looks like.
+- The standard you're holding it to.
+
+Ask the consultant to confirm or correct the framing before you tear in. (This is Function 1 — never critique a target you haven't agreed.)
+
+## Step 4 — Hunt (the escalation)
+
+Unlike default CTP, do **not** wait for a trigger. Run all five functions against the target whether or not a trigger fired:
+
+1. **Problem definition** — is the work solving the right problem? Is the surface ask masking a different underlying need?
+2. **Context completeness** — what's missing? Name detectable gaps, and name the *shape* of what you structurally can't see (history, politics, tacit knowledge). Ask for it.
+3. **Input examination** — decompose each material claim to the link that doesn't hold. Fall back to first principles where evidence is thin. For every number, ask where it came from.
+4. **Direction maintenance** — has the work drifted from its stated intent across the conversation?
+5. **Correction metabolism** — (applies once the consultant responds) extract principles from their corrections and sweep for repeats.
+
+Decompose as deeply as the work is complex — full hypothesis/issue tree for a high-stakes deliverable; lighter for a small artifact.
+
+## Step 5 — Proactive provenance
+
+Flag every weak-sourced or unverifiable figure **at the point it appears** in the work, not only if asked. For each, explicitly separate:
+- **"I can challenge this"** — reasoning/consistency problems you can argue from what's here.
+- **"I can't verify this without source data"** — a churn rate, an effort estimate, a benchmark. Name it as a gap; do not pretend to verify it. You are a sharpener, not an oracle.
+
+## Step 6 — Output: a challenge register
+
+Return a structured register, most-serious first. For each item:
+
+| Field | Content |
+|---|---|
+| **Issue** | One line — what's wrong or unverified |
+| **Function / trigger** | Which of the five functions / which trigger type |
+| **Confidence** | Calibrated: **High** (inconsistent with the work's own evidence) · **Medium** (weak reasoning or soft source) · **Conditional** ("you're right *if* X holds") · **Unverifiable** (needs source data) |
+| **Why it matters** | The consequence if it ships as-is |
+| **What would resolve it** | The source, the fix, or the decision needed |
+
+Keep the tone of a colleague, not a critic: state what makes you uncertain, show the reasoning, ask for the source, and leave room for the consultant to be right. Batch — one structured register, not a stream of separate messages.
+
+## Step 7 — Flag where independence would bite harder
+
+You are the same model reasoning over the same context you are critiquing — you mitigate sycophancy by instruction, not by independence. Where a challenge would materially benefit from a genuinely independent check (a fresh-context critic, a second pair of eyes, or real source data), **say so explicitly**. Don't overstate the reliability of your own critique.
+
+## What `/critty` does NOT do
+
+- It does not verify facts it lacks the source data for — it names them as gaps.
+- It does not rewrite the work unless asked — it pressure-tests it. Offer to fix after the register, on the consultant's call.
+- It does not nag afterward. Once the register is delivered and the consultant decides, return to normal governed behavior.

--- a/.design/solution-design-v2.md
+++ b/.design/solution-design-v2.md
@@ -1,0 +1,127 @@
+---
+version: 2
+prd: prd-v2.md
+status: draft
+date: 2026-07-23
+author: Mariam Titus George
+previous: solution-design-v1.md
+---
+
+# Solution Design — Critical Thought Partner + `/critty`
+
+Stack: Claude Code prompt components (Markdown) + Python eval rubrics. No app runtime. The "solution" is prose + governance wiring + deterministic eval checks. All changes are **additive and backward-compatible** — no existing component's behaviour or output shape changes.
+
+## Component Structure
+
+```
+CLAUDE.md                                              — MODIFIED: add lean "You Are a Critical Thought
+                                                         Partner, Not a Typist" section (after "Reason from
+                                                         Evidence"); add CTP row to the Mandatory Governance
+                                                         Standards table.
+knowledge/standards/
+  critical_thought_partner_protocol.md                 — NEW: the depth. Governing principle, the Governor
+                                                         (triggers T1–T5 + suppression S1–S4 + form/depth),
+                                                         the five functions, detection mechanisms, worked
+                                                         example, v1 limits, related-standards pointer.
+.claude/commands/
+  critty.md                                            — NEW: the on-demand escalation command. 7 steps:
+                                                         load full protocol → scope → align → hunt (5 fns) →
+                                                         proactive provenance → challenge register → flag
+                                                         where independence bites harder.
+evals/
+  registry.yaml                                        — MODIFIED: add two component cases (`critty`,
+                                                         `critical-thought-partner`).
+  rubrics/component/
+    critty.py                                          — NEW: deterministic evaluate(target) for critty.md.
+    critical_thought_partner.py                        — NEW: deterministic evaluate(target) for the standard
+                                                         + CLAUDE.md wiring.
+tests/quality_metrics.yaml                             — MODIFIED (optional): add structural rules so
+                                                         test_agent.py recognises the new command/standard.
+```
+
+Contribution tier: all paths (CLAUDE.md, `.claude/commands/`, `knowledge/standards/`, `evals/`) are **Architect-tier**. Author (Mariam) is an Architect — clears `enforce-contribution-scope.yml`.
+
+## Data & Contract Model
+
+There are no engagement-data contracts here — the "contract" is the required structure each artifact must contain, which the eval checks enforce.
+
+```yaml
+# critty.md — command contract
+name: critty
+description: "on-demand hard critical pressure-test"   # frontmatter required by test_agent.py
+required_behaviours:                                   # each = one deterministic eval check
+  - load_full_protocol            # Step 1 reads the standard file in full (+ fallback if absent)
+  - scope_target                  # Step 2 resolves what to critique
+  - align_before_critique         # Step 3 confirms framing first (Function 1)
+  - five_function_hunt            # Step 4 runs all five functions regardless of triggers
+  - proactive_provenance_split    # Step 5 "I can challenge" vs "I can't verify without source data"
+  - challenge_register            # Step 6 ranked table w/ calibrated confidence
+  - independence_flag             # Step 7 names where a fresh-context critic bites harder
+```
+
+```yaml
+# critical_thought_partner_protocol.md — standard contract
+required_sections:
+  - governing_principle           # "challenge everything is as useless as challenge nothing"
+  - governor_triggers             # T1–T5 (materiality, contradiction, load-bearing assumption,
+                                  #        framing mismatch, consequential gap)
+  - governor_suppression          # S1–S4 (already-decided, cosmetic, closed, low-impact)
+  - five_functions                # problem def, context completeness, input exam, direction, correction
+  - detection_mechanisms          # structural / mechanism / procedural / inconsistency / domain-template
+  - worked_example
+  - v1_limits                     # "sharpener not oracle" + "instruction not independence"
+# CLAUDE.md wiring (checked by the same evaluator):
+claude_md_wiring:
+  - core_section_present          # "Critical Thought Partner, Not a Typist" heading
+  - governance_table_row          # CTP row in the Mandatory Governance Standards table
+  - zero_challenges_framing       # "most turns need no challenge" governing principle stated in core
+  - limits_present                # both v1 limits stated in core
+```
+
+Rationale for the two-artifact split (lean core + deep standard): mirrors the existing governance pattern (Security/Auditability/Context each have a lean CLAUDE.md pointer + a full `knowledge/standards/*.md`). Keeps CLAUDE.md scannable; puts the exact rules where an agent that needs depth can load them; `/critty` force-loads the depth.
+
+## Agent / Pipeline Steps
+
+| Name | Type | Input | Output | Purpose |
+| --- | --- | --- | --- | --- |
+| `critty` | command (skill) | consultant invocation (± target) | challenge register in-chat | On-demand hard pressure-test |
+| CTP behaviour | governance prose | every turn's context | zero-or-one batched challenge | Always-on governed challenge |
+| `rubrics.component.critty` | eval evaluator | `.claude/commands/critty.md` | `list[CheckResult]` | Verify command completeness |
+| `rubrics.component.critical_thought_partner` | eval evaluator | `knowledge/standards/critical_thought_partner_protocol.md` (+ reads CLAUDE.md) | `list[CheckResult]` | Verify standard + wiring |
+
+No agent invocations, no pipeline steps, no model calls added. The eval evaluators follow the existing `rubrics/component/*.py` convention: `evaluate(target)` where target is the resolved file path, returning soft `CheckResult`s with a small number of `hard_fail=True` on genuinely load-bearing structure (e.g. frontmatter, protocol-load step).
+
+## Integration Points
+
+| Existing component / step | How it's touched | Risk |
+| --- | --- | --- |
+| `CLAUDE.md` | Additive: one new core section + one governance-table row. No existing rule changed. | Low |
+| Mandatory Governance Standards contract | New standard becomes binding on all agents *by reference* — but v1 is behavioural, no per-agent edits, so no agent output changes | Low |
+| `evals/registry.yaml` | Two new component cases appended; existing cases untouched | Low |
+| `evals/run_experiment.py` | No change — new cases use the default `rubrics.component.{name}` evaluator resolution already in place | Low |
+| `scripts/test_agent.py` / `tests/quality_metrics.yaml` | New command/standard must pass structural checks; may need a rule so they're recognised | Low |
+| `require-harness.py` hook | Edits to component paths are permitted because this bb-* cycle is active | Low |
+| Pipeline altitude (`--altitude pipeline`) | Must stay green; change is additive governance with no data-flow effect | Low |
+| Every downstream agent | None consume CTP output as data — behavioural only | Low |
+
+## Technical Decisions
+
+**Decision:** Two artifacts — a lean CLAUDE.md core section + a full `knowledge/standards/` protocol — rather than one.
+**Alternatives considered:** (a) Everything inline in CLAUDE.md; (b) standard only, no core section.
+**Rationale:** Matches the established governance pattern (Security/Auditability/Context). The core must be self-sufficient for the common case; depth is loaded on demand by `/critty`. (a) bloats CLAUDE.md; (b) leaves the always-on behaviour without a home in the file every agent reads.
+**Trade-offs:** Two files to keep in sync — the eval's cross-link + limits-present checks guard drift.
+
+**Decision:** Eval gate is structural presence + protocol completeness, not a live-behaviour LLM judge.
+**Alternatives considered:** An LLM-judge scoring real transcripts for good/bad challenges.
+**Rationale:** CTP's own v1 limit — it's the same model over the same context; a credible quality judge needs a fresh-context critic, which is out of scope. Deterministic checks are honest about what they verify (the artifacts say the right things) vs. what they can't (runtime behaviour). Consistent with this cycle's "deterministic checks only, judges skipped" precedent (PRD v1).
+**Trade-offs:** The gate can't catch a well-worded-but-behaviourally-inert protocol. Accepted and named as a v1 limit; fresh-context-critic eval is the planned evolution.
+
+**Decision:** No per-agent prompt edits this cycle; CTP binds via the mandatory-standards contract.
+**Alternatives considered:** Inject a CTP block into all ~22 agent prompts now.
+**Rationale:** Keeps the change additive and low-risk (zero existing-output change → all current evals stay green). Broad per-agent embedding is a larger, separately-testable cycle.
+**Trade-offs:** Uptake relies on the standards-contract inheritance rather than explicit per-agent text; flagged in PRD Out of Scope.
+
+**Decision:** `/critty` degrades gracefully when the protocol file is absent (fallback to CLAUDE.md summary, with a stated limitation).
+**Alternatives considered:** Hard-fail if the file is missing.
+**Rationale:** The command may be run on a branch that predates the standard; a useful degraded mode beats a dead command, and honesty about the limitation matches the "instruction not independence" ethos.
+**Trade-offs:** Slightly more prose in the command; worth it for robustness.

--- a/.design/ux-design-v2.md
+++ b/.design/ux-design-v2.md
@@ -1,0 +1,111 @@
+---
+version: 2
+prd: prd-v2.md
+status: draft
+date: 2026-07-23
+author: Mariam Titus George
+previous: ux-design-v1.md
+---
+
+# UX Design — Critical Thought Partner + `/critty`
+
+The "user" here is the **consultant** working in a Claude Code chat. There is no GUI; the interaction surface is (a) Cortex's in-conversation challenge behaviour and (b) the `/critty` slash command. UX = the *logic* of when Cortex speaks, what it returns, and how the consultant recovers/overrides.
+
+## User Flows
+
+### Flow A — Always-on governed challenge (passive)
+
+```
+[consultant asserts something / asks for an artifact]
+        │
+        ▼
+[Cortex runs the Governor silently]
+        │
+        ├──[no trigger fires OR a suppression rule applies]──▶ [do the work, zero challenges]
+        │                                                              │
+        │                                                              ▼
+        │                                                     (this is the common case)
+        │
+        └──[≥1 trigger fires AND not suppressed]──▶ [ONE batched, structured push]
+                                                            │
+                                    ┌───────────────────────┼───────────────────────┐
+                                    ▼                       ▼                       ▼
+                          [inline question         [batched structured     [stop & align on the
+                           — single concern]         push — several]         problem — foundational]
+                                    │                       │                       │
+                                    └───────────────────────┴───────────────────────┘
+                                                            │
+                                                            ▼
+                                          [consultant defends / corrects / closes topic]
+                                                            │
+                          ┌─────────────────────────────────┼─────────────────────────────────┐
+                          ▼                                  ▼                                   ▼
+              [informed call made ──▶ S1:                [correction given ──▶            [topic closed ──▶ S3:
+               do not relitigate]                         metabolize: restate,             stay silent]
+                                                          sweep for repeats]
+```
+
+### Flow B — `/critty` on-demand hard pressure-test (active escalation)
+
+```
+[consultant types  /critty  (optionally /critty <file|section|free text>)]
+        │
+        ▼
+[Step 1: force-load knowledge/standards/critical_thought_partner_protocol.md IN FULL]
+        │
+        ├──[protocol file missing on branch]──▶ [say so; fall back to CLAUDE.md CTP section; note the limitation] ──┐
+        │                                                                                                            │
+        ▼                                                                                                            │
+[Step 2: scope the target]                                                                                          │
+        │                                                                                                            │
+        ├──[target named]────────▶ use it                                                                            │
+        ├──[no target]───────────▶ use current / most-recent substantive artifact                                   │
+        └──[genuinely ambiguous]─▶ ask ONE short scoping question ──▶ [consultant answers] ──┐                       │
+                                                                                             │                       │
+        ┌────────────────────────────────────────────────────────────────────────────────────┘                     │
+        ▼                                                                                                            │
+[Step 3: align — state read of purpose/audience/"good" + the standard; ask to confirm/correct]                      │
+        │                                                                                                            │
+        ▼                                                                                                            │
+[consultant confirms or corrects framing]                                                                           │
+        │                                                                                                            │
+        ▼                                                                                                            │
+[Step 4: HUNT — run all 5 functions regardless of triggers (silence bias suspended)] ◀──────────────────────────────┘
+        │
+        ▼
+[Step 5: proactive provenance — flag each weak/unverifiable figure at point of appearance;
+         split "I can challenge this" vs "I can't verify this without source data"]
+        │
+        ▼
+[Step 6: OUTPUT — one challenge register, most-serious-first, calibrated confidence]
+        │
+        ▼
+[Step 7: flag where a genuinely independent check would bite harder]
+        │
+        ▼
+[consultant decides per item ──▶ Cortex offers to fix on request; then returns to normal governed behaviour]
+```
+
+## Screen & Component States
+
+The "component" is Cortex's response. States enumerated as response modes:
+
+| State | Trigger | What the consultant sees |
+| --- | --- | --- |
+| Silent (do the work) | No Governor trigger, or a suppression rule applies | The requested work, no challenge. **The common case.** |
+| Inline question | Exactly one concern crosses a trigger | A single, short question embedded near the relevant point |
+| Batched push | Several related concerns cross triggers | ONE structured block of concerns — never serial nags |
+| Stop-and-align | Foundational disagreement on the problem itself | Cortex pauses before producing; proposes a re-frame and asks to align |
+| `/critty` aligning | `/critty` invoked | Cortex's read of purpose/audience/standard + a "confirm or correct?" prompt |
+| `/critty` scoping | `/critty` with ambiguous target | One short scoping question |
+| `/critty` register | `/critty` hunt complete | A ranked challenge register table + independence flag |
+| Fallback | `/critty` run where protocol file is absent | Notice that it's running from the CLAUDE.md summary, with the stated limitation |
+
+## Error States
+
+| Error | Cause | User-facing message | Recovery |
+| --- | --- | --- | --- |
+| Protocol file missing | `/critty` on a branch without `knowledge/standards/critical_thought_partner_protocol.md` | "The full CTP protocol file isn't on this branch — I'll run from the CLAUDE.md summary, which is lighter. Depth (exact triggers, worked example) is unavailable." | Proceed in fallback; note limitation |
+| Ambiguous target | `/critty` with no clear current artifact | "What should I pressure-test — the ROI model, the deck, or something else?" | Consultant names the target; proceed |
+| Over-challenge risk (design guardrail, not a runtime error) | Governor mis-fires and challenges cosmetic/closed items | (Prevented, not surfaced) — suppression rules S1–S4 gate it out | Consultant can say "you already made the call / topic closed"; S1/S3 silence it |
+| Verification overreach | Consultant asks `/critty` to *confirm* a figure | "I can flag the reasoning around this number, but I can't verify the figure itself without the source data — that's a gap, not a green light." | Named as unverifiable in the register; consultant supplies source or accepts the gap |

--- a/.prd/backlog.md
+++ b/.prd/backlog.md
@@ -1,0 +1,6 @@
+# Findings Backlog
+
+Plain notes — small issues parked by past reviews that weren't worth a full plan. Append-only, non-versioned. A future `/bb-prd` folds in anything still relevant (rewriting `- [ ]` to `- [done vN]`).
+
+- [ ] evals/registry.yaml:critty,critical-thought-partner — No negative/stripped fixture proves the checks discriminate; add a WITH/WITHOUT fixture pair (like roi-excel-generator) or an inline assertion that evaluate() on a stripped copy scores <0.80 (from PR #97 review)
+- [ ] CLAUDE.md:142 — CTP suppression summary drops "low confidence AND" from standard rule S4 ("Low confidence AND low impact"); the self-sufficient CLAUDE.md section applies a looser suppression rule than the standard (from PR #97 review)

--- a/.prd/prd-v1.md
+++ b/.prd/prd-v1.md
@@ -1,6 +1,6 @@
 ---
 version: 1
-status: built
+status: archived
 date: 2026-07-07
 author: Mariam Titus George
 previous: null

--- a/.prd/prd-v2.md
+++ b/.prd/prd-v2.md
@@ -1,6 +1,6 @@
 ---
 version: 2
-status: draft
+status: built
 date: 2026-07-23
 author: Mariam Titus George
 previous: prd-v1.md

--- a/.prd/prd-v2.md
+++ b/.prd/prd-v2.md
@@ -1,0 +1,86 @@
+---
+version: 2
+status: draft
+date: 2026-07-23
+author: Mariam Titus George
+previous: prd-v1.md
+---
+
+# PRD v2 — Critical Thought Partner (CTP): governed challenge behaviour + `/critty` on-demand pressure-test
+
+## 1. Problem
+
+Cortex is trusted to produce defensible, evidence-traced consulting deliverables — but today it behaves like a **typist, not a thought partner**. It takes the consultant's inputs largely at face value: it will happily model a value lever off a population number that doesn't fit the lever's mechanics, carry a surface ask that has drifted from the agreed problem, or produce an artifact resting on an uncited, load-bearing assumption. The CLAUDE.md "reason from evidence" rules govern what Cortex *produces*; nothing governs whether Cortex *challenges the input* before producing.
+
+This is a live, expensive failure mode. In the MyState IGNITE engagement a single unexamined population figure (416,649 "all retail customers" used for an *in-app* cross-sell lever, when only 372,160 are active digital users) was a ~$4M overstatement that a thought partner would have caught by asking one question. The system did not ask.
+
+Two things are missing:
+1. **An always-on discipline** for *when* and *how* Cortex should challenge — one that does not turn Cortex into a contrarian that questions everything (a partner that challenges everything is as useless as one that challenges nothing). The right number of challenges on most turns is zero; the discipline has to be *governed* by triggers and suppression rules, not volume.
+2. **An on-demand escalation** — a way for the consultant to deliberately turn the dial to maximum and say "tear this apart" for a specific piece of work, suspending the silence bias and hunting for weaknesses.
+
+If we don't solve it: Cortex keeps shipping the consultant's blind spots downstream into client-facing deliverables, and the one thing a senior consultant does that a document generator can't — pressure-test the thinking before the client sees it — stays absent.
+
+## 2. Solution
+
+Introduce **Critical Thought Partner (CTP)** as a governed, first-class behaviour in two coordinated layers:
+
+- **(a) Always-on, governor-gated challenge behaviour.** A lean, self-sufficient "You Are a Critical Thought Partner, Not a Typist" section in `CLAUDE.md` core, backed by a new mandatory governance standard `knowledge/standards/critical_thought_partner_protocol.md` (the depth: the Governor's triggers/suppression rules, the five functions, gap-detection mechanisms, a worked example, and honest v1 limits). The protocol is registered in the CLAUDE.md Mandatory Governance Standards table alongside Auditability, Context, Security, and Design. The governing principle: challenge is gated by triggers (materiality, contradiction, load-bearing unsupported assumption, framing mismatch, consequential gap) and suppression rules (already-decided, cosmetic, closed topic, low-impact) — most turns produce zero challenges, and that is the system working.
+
+- **(b) `/critty` — on-demand escalation.** A new `.claude/commands/critty.md` skill the consultant invokes to force a hard pressure-test of the current work regardless of triggers. It force-loads the full protocol, aligns on what it's critiquing before tearing in, runs all five functions in "hunt mode," flags weak/unverifiable figures at the point they appear (separating "I can challenge this" from "I can't verify this without source data"), and returns a structured **challenge register** ranked most-serious-first with calibrated confidence. It is honest about its own ceiling: it is the same model reasoning over the same context, so it names where a genuinely independent check would bite harder.
+
+The design is deliberately **honest about v1 limits**: CTP is a behavioural discipline delivered through prompts. It is a *sharpener, not an oracle* (it raises questions and names gaps; it cannot verify a figure without source data) and *instruction, not independence* (it mitigates sycophancy by instruction, not by a fresh-context critic). The protocol and `/critty` both state these limits rather than overselling.
+
+Reference material already exists as working prototypes on the stale branches `mariamt/20260714-ctp-governance` and `mariamt/20260714-critty-skill` (cut before the ROI-provenance work merged); this PRD re-lands that content cleanly on current `main` through the harness.
+
+## 3. Scope
+
+| This PRD covers | This PRD does NOT cover |
+| --- | --- |
+| New standard `knowledge/standards/critical_thought_partner_protocol.md` (Governor, five functions, detection mechanisms, worked example, v1 limits) | Re-writing existing standards (Auditability, Context, Security, Design) — CTP *reinforces and points at* them, never replaces |
+| Lean "You Are a Critical Thought Partner, Not a Typist" section in `CLAUDE.md` core | Changing the existing "Reason from Evidence" / Handling Missing Data rules (CTP adds input-examination + direction-keeping on top) |
+| Register CTP in the CLAUDE.md Mandatory Governance Standards table | Rebuilding the governance table format or the other rows |
+| New `/critty` command (`.claude/commands/critty.md`) — force-load protocol, align, hunt, challenge register, independence flag | Per-agent embedding of CTP into every one of the ~22 agent prompts (they inherit via the mandatory-standards contract; individual agent edits are a later cycle) |
+| A deterministic eval case for the `/critty` command (structural: required sections/behaviours present) + governance-doc presence checks | An LLM-judge that scores live challenge *quality* on a transcript (a fresh-context critic eval is a planned evolution, explicitly a v1 limit) |
+| Verify the change is additive and the pipeline-altitude experiment stays green | Auto-emission of challenge logs into the assumptions register / ENGAGEMENT_JOURNAL wiring (behavioural only in v1) |
+
+## 4. Success Metrics
+
+| Metric | Target |
+| --- | --- |
+| New governance standard present and linked from CLAUDE.md core + governance table | Both links resolve; standard file exists |
+| `/critty` command is structurally valid and discoverable | Valid frontmatter (`name`, `description`); `test_agent.py` passes on the changed files |
+| `/critty` protocol completeness | Command file contains all required behaviours: load full protocol, align-before-critique, five-function hunt, proactive provenance split, challenge-register output, independence flag |
+| Governed (not contrarian) framing is explicit | CLAUDE.md section + protocol both state the "most turns = zero challenges" governing principle and the suppression rules |
+| No downstream regression | `--altitude pipeline` experiment stays green; existing component evals unaffected |
+| Honesty about v1 limits | Both artifacts explicitly state "sharpener not oracle" and "instruction not independence" |
+
+## 5. Eval Acceptance Criteria
+
+CTP is a behavioural discipline delivered through prompts; per its own v1 limits it cannot be fully verified by deterministic checks (challenge *quality* needs a fresh-context critic, which is out of scope). The gate is therefore **structural presence + protocol completeness + no-downstream-regression**, not a live-behaviour judge.
+
+| Component | `evals/registry.yaml` cases | Threshold | Altitude |
+| --- | --- | --- | --- |
+| `critty` (NEW command) | Author new case `critty`: deterministic `code` checks — frontmatter valid; body contains the required sections (load-full-protocol, scope, align-before-critique, five-function hunt, proactive-provenance split, challenge-register table, independence flag) | 0.80 | unit |
+| `critical-thought-partner` governance (NEW) | Author new case `critical-thought-partner`: deterministic `code` checks — standard file exists; CLAUDE.md core contains the CTP section; governance-standards table has the CTP row; both cross-links resolve; the "sharpener not oracle" + "instruction not independence" limits present | 0.80 | unit |
+| Structural gate (all changed files) | `python scripts/test_agent.py --branch HEAD --base-branch origin/main` | pass | unit |
+| Downstream integrity | `python evals/run_experiment.py --altitude pipeline` must stay green (change is additive governance) | no regression | pipeline |
+
+- **NEW component:** fresh eval cases (`critty`, `critical-thought-partner`) MUST be authored as part of this work, with the deterministic `code` evaluators added under `evals/rubrics/component/`.
+- The change is additive and backward-compatible; it must not alter any existing component's output, so all current component + deliverable evals must remain green.
+
+## 6. Out of Scope
+
+- Embedding CTP into each of the ~22 individual agent prompts (inherited via the mandatory-standards contract this cycle; per-agent edits are a future cycle).
+- A fresh-context / independent critic that reasons outside the critiqued context (named as a v1 limit and a planned evolution — not built here).
+- LLM-judge scoring of live challenge quality on real transcripts.
+- Wiring CTP challenges into the assumptions register / ENGAGEMENT_JOURNAL automatically.
+- Any change to the ROI provenance work (PRD v1) or other components' behaviour.
+
+## Dependencies & Risks
+
+| Dependency/Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Over-triggering: CTP becomes a contrarian that challenges everything | Erodes consultant trust; noise buries signal | Governor is the core of the design — triggers + suppression rules + "most turns = zero"; both artifacts lead with this |
+| Overselling reliability: consultant treats a challenge as verification | False confidence in un-sourced figures | "Sharpener not oracle" + explicit "I can't verify this without source data" split is mandatory in both artifacts, enforced by eval |
+| Un-testable behaviour: prompts don't guarantee runtime behaviour | Eval gate can only check presence, not live challenge quality | Honestly scoped: structural + completeness gate now; fresh-context-critic eval flagged as planned evolution |
+| Governance sprawl in CLAUDE.md | CLAUDE.md bloat | Core section is lean and self-sufficient; depth lives in the standard, linked once |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,30 @@ Every analysis must be grounded in:
 - Present guesses as facts
 - Use optimistic math without downside cases
 
+### You Are a Critical Thought Partner, Not a Typist
+
+A senior consultant questions before producing, to make sure the work is built on solid ground. You do the same. You challenge weak input, surface what's missing, and keep the work pointed at the original problem — **but only when it earns its cost.**
+
+**Challenge only when it makes sense.** Speak up when at least one of these holds, and stay silent otherwise:
+- It changes a number, framing, or structure in something the client will see (materiality)
+- It contradicts evidence already in front of you
+- The output would rest on an unsupported, load-bearing assumption
+- The current ask has drifted from the problem you agreed to solve
+- Something is missing whose absence would change the answer
+
+Stay silent — just do the work — when: you already raised it and they made an informed call; it's cosmetic or easily reversed; they explicitly closed the topic; or it's low-impact (log it to the assumptions register instead of interrupting). **Most turns need no challenge. That is the system working, not failing.** When you do challenge, batch every concern into one structured push — never a string of nags.
+
+**When you challenge, do it like a partner:**
+
+1. **Agree the problem first.** Share your read of what's being solved, for whom, and what success looks like — then ask if it matches. Don't restate unilaterally; reach it together. Separate the surface ask from the underlying need. Match how deeply you decompose to how complex the problem is.
+2. **Carry "so what" through to the output.** Every solution states what it means for the stakeholder it's presented to.
+3. **Surface what's missing — including what you can't see.** For gaps you can detect, follow the Handling Missing Data rules. For context you *can't* detect (deal history, politics, tacit knowledge), name the shape of what you're missing and ask before producing.
+4. **Pressure-test input, transparently.** Test assertions by decomposing to the link that doesn't hold; fall back to first principles when evidence is thin. State what makes you uncertain and ask where a number or claim came from. Never confront, never lecture — invite a defense.
+5. **Hold the line on the original problem.** Keep the agreed problem in view. Re-anchor when you've drifted before producing the wrong thing — and pull the consultant back when *they* drift from their own stated intent.
+6. **Metabolize correction.** When corrected, restate what you now understand to confirm, extract the underlying principle, sweep the rest of the work for the same mistake, and ask what else the same blind spot may have touched.
+
+This sharpens the consultant's thinking and pressure-tests the output before a client ever sees it. When a consultant wants a hard, on-demand pressure-test regardless of triggers, they invoke `/critty`. Full triggers, suppression rules, and examples: `knowledge/standards/critical_thought_partner_protocol.md`.
+
 ### You Follow README.md Standards
 
 The [README.md](README.md) is the authoritative source for:
@@ -225,6 +249,7 @@ ALL agents (current and future) MUST comply with these protocols:
 | **Auditability Protocol** | `knowledge/standards/auditability_protocol.md` | Journal entries, telemetry, output provenance, checkpoint logging |
 | **Context Management Protocol** | `knowledge/standards/context_management_protocol.md` | File size checks, chunking, context preservation |
 | **Security Protocol** | `knowledge/standards/security_protocol.md` | Prompt injection defense, untrusted data handling, MCP query anonymization, web source validation, stakeholder intelligence bounds |
+| **Critical Thought Partner Protocol** | `knowledge/standards/critical_thought_partner_protocol.md` | When/how to challenge consultant input — triggers, suppression rules, the five functions, drift detection |
 | **Unified Design System** | `knowledge/design-system.md` | Visual output standards, brand colors, typography, layout patterns |
 
 **Non-negotiable rules for every agent:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Stay silent — just do the work — when: you already raised it and they made a
 5. **Hold the line on the original problem.** Keep the agreed problem in view. Re-anchor when you've drifted before producing the wrong thing — and pull the consultant back when *they* drift from their own stated intent.
 6. **Metabolize correction.** When corrected, restate what you now understand to confirm, extract the underlying principle, sweep the rest of the work for the same mistake, and ask what else the same blind spot may have touched.
 
-This sharpens the consultant's thinking and pressure-tests the output before a client ever sees it. When a consultant wants a hard, on-demand pressure-test regardless of triggers, they invoke `/critty`. Full triggers, suppression rules, and examples: `knowledge/standards/critical_thought_partner_protocol.md`.
+This sharpens the consultant's thinking and pressure-tests the output before a client ever sees it. Two honest limits: you're a **sharpener, not an oracle** — you can challenge a figure's logic but can't verify it without the source data; and you're **instruction, not independence** — the same model reasoning over the same context, so name where a genuinely independent check would bite harder. When a consultant wants a hard, on-demand pressure-test regardless of triggers, they invoke `/critty`. Full triggers, suppression rules, and examples: `knowledge/standards/critical_thought_partner_protocol.md`.
 
 ### You Follow README.md Standards
 

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -150,6 +150,22 @@ components:
     code: [hypothesis_validation_statuses, usecase_candidates_present, usecase_classification_present]
     judge: [synthesis_faithful_to_workshops]
 
+  # critty (#95) — verifies `.claude/commands/critty.md` (tickets #93/#94's
+  # on-demand CTP escalation skill) force-loads the full protocol (with a
+  # named fallback), scopes/aligns before critiquing, hunts all five CTP
+  # functions without waiting for a trigger, splits proactive provenance into
+  # challengeable vs. unverifiable, emits the five-field challenge-register
+  # table, flags where independence would bite harder, and states what
+  # /critty does NOT do. Deterministic code checks only — no judge this cycle.
+  critty:
+    altitude: component
+    threshold: 0.80
+    evaluator: rubrics.component.critty
+    input: .claude/commands/critty.md
+    code: [frontmatter_valid, protocol_load_step, fallback_when_absent, scope_target_step,
+           align_before_critique_step, five_functions_hunt, proactive_provenance_split,
+           challenge_register_table, independence_flag, not_do_section]
+
 # Pipeline (integration) altitude — the most important. When ANY component
 # changes, run orchestrate.py end-to-end on a golden engagement and check the
 # inter-agent contracts + final deliverable still hold.

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -166,6 +166,25 @@ components:
            align_before_critique_step, five_functions_hunt, proactive_provenance_split,
            challenge_register_table, independence_flag, not_do_section]
 
+  # critical-thought-partner (#95) — verifies the CTP STANDARD
+  # (knowledge/standards/critical_thought_partner_protocol.md, ticket #93) is
+  # structurally complete (governing principle, T1-T5 triggers, S1-S4
+  # suppression rules, the five functions, the five detection mechanisms, a
+  # worked example, both v1 limits) AND that CLAUDE.md is actually wired to
+  # it (core section heading, governance-table row, the "most turns need no
+  # challenge" framing, both v1 limits echoed in the core section).
+  # CLAUDE.md is resolved via rubrics.base.repo_root() — never a hardcoded
+  # path. Deterministic code checks only — no judge this cycle.
+  critical-thought-partner:
+    altitude: component
+    threshold: 0.80
+    evaluator: rubrics.component.critical_thought_partner
+    input: knowledge/standards/critical_thought_partner_protocol.md
+    code: [governing_principle, governor_triggers_t1_t5, suppression_s1_s4, five_functions,
+           five_detection_mechanisms, worked_example, v1_limits_standard,
+           claude_md_core_section_heading, claude_md_governance_table_row,
+           claude_md_zero_challenge_framing, claude_md_v1_limits_in_core]
+
 # Pipeline (integration) altitude — the most important. When ANY component
 # changes, run orchestrate.py end-to-end on a golden engagement and check the
 # inter-agent contracts + final deliverable still hold.

--- a/evals/rubrics/component/critical_thought_partner.py
+++ b/evals/rubrics/component/critical_thought_partner.py
@@ -1,0 +1,211 @@
+"""critical-thought-partner component evaluator (objective, code-only — no LLM).
+
+Verifies TWO things at once — mirroring the sibling rubric.component.critty
+in structure but split across two sources:
+
+  1. The STANDARD file itself (`target` =
+     knowledge/standards/critical_thought_partner_protocol.md, ticket #93) is
+     structurally complete: the governing principle, the Governor's five
+     triggers (T1-T5) and four suppression rules (S1-S4), the five CTP
+     functions, the five detection mechanisms, a worked example, and both
+     documented v1 limits ("sharpener, not oracle" / "instruction, not
+     independence").
+
+  2. CLAUDE.md is actually WIRED to that standard (ticket #93's CLAUDE.md
+     changes): the CTP core section heading exists, the governance table has
+     a row pointing at the standard's path, the "most turns need no
+     challenge" / zero-challenge-by-default framing is present, and both v1
+     limits are echoed in the core section (not just the deep-dive standard).
+
+CLAUDE.md is resolved via `rubrics.base.repo_root()` — never a hardcoded
+absolute path — so this rubric keeps working from any checkout/worktree.
+
+target: path to critical_thought_partner_protocol.md OR raw text (`_read`).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from rubrics.base import CheckResult, repo_root
+
+
+def _read(x: str) -> str:
+    try:
+        p = Path(x)
+        return p.read_text(errors="replace") if p.exists() else x
+    except (OSError, ValueError):
+        return x
+
+
+def _present(pattern: str, text: str, flags: int = re.I) -> bool:
+    return bool(re.search(pattern, text, flags))
+
+
+def _bool_check(name: str, ok: bool, *, hard_fail: bool = False, soft_floor: float = 0.0,
+               detail: str = "") -> CheckResult:
+    return CheckResult(name, 1.0 if ok else soft_floor, ok, hard_fail=hard_fail, detail=detail)
+
+
+def _ratio_present(name: str, patterns: list[str], text: str, *, hard_fail: bool = False) -> CheckResult:
+    found = [p for p in patterns if _present(p, text)]
+    ok = len(found) == len(patterns)
+    score = len(found) / len(patterns)
+    return CheckResult(name, score, ok, hard_fail=hard_fail,
+                       detail=f"{len(found)}/{len(patterns)} present: {found}")
+
+
+_CORE_HEADING = r"###\s*You Are a Critical Thought Partner, Not a Typist"
+
+
+def _section(text: str, heading_pattern: str) -> str:
+    """Text from a `### heading` match up to the next `### ` heading (or EOF) —
+    scopes a check to one CLAUDE.md subsection for a more discriminating wiring
+    check than a whole-file substring search."""
+    m = re.search(heading_pattern, text, re.I)
+    if not m:
+        return ""
+    rest = text[m.end():]
+    nxt = re.search(r"\n### ", rest)
+    return rest[:nxt.start()] if nxt else rest
+
+
+# --- STANDARD file checks (target) ------------------------------------------
+
+def _check_governing_principle(text: str) -> CheckResult:
+    ok = _present(r"right number of challenges is zero", text) and \
+         _present(r"gated by triggers and suppression rules", text)
+    return _bool_check("governing_principle", ok,
+                       detail="governing-principle statement present" if ok
+                       else "governing principle ('right number of challenges is zero' / "
+                            "'gated by triggers and suppression rules') missing or altered")
+
+
+def _check_governor_triggers(text: str) -> CheckResult:
+    return _ratio_present("governor_triggers_t1_t5",
+                          [r"\bT1\b", r"\bT2\b", r"\bT3\b", r"\bT4\b", r"\bT5\b"], text)
+
+
+def _check_suppression_rules(text: str) -> CheckResult:
+    return _ratio_present("suppression_s1_s4",
+                          [r"\bS1\b", r"\bS2\b", r"\bS3\b", r"\bS4\b"], text)
+
+
+_FIVE_FUNCTIONS = [
+    r"Problem definition",
+    r"Context completeness",
+    r"Input examination",
+    r"Direction maintenance",
+    r"Correction metabolism",
+]
+
+
+def _check_five_functions(text: str) -> CheckResult:
+    return _ratio_present("five_functions", _FIVE_FUNCTIONS, text, hard_fail=True)
+
+
+_FIVE_DETECTION_MECHANISMS = [
+    r"\bStructural\b",
+    r"Mechanism\s*/\s*first-principles",
+    r"\bProcedural\b",
+    r"\bInconsistency\b",
+    r"Domain-template",
+]
+
+
+def _check_five_detection_mechanisms(text: str) -> CheckResult:
+    return _ratio_present("five_detection_mechanisms", _FIVE_DETECTION_MECHANISMS, text)
+
+
+def _check_worked_example(text: str) -> CheckResult:
+    ok = _present(r"Worked example", text) and _present(r"\*\*Consultant:\*\*", text) and \
+         _present(r"\*\*Cortex:\*\*", text)
+    return _bool_check("worked_example", ok,
+                       detail="worked Consultant/Cortex example dialogue present" if ok
+                       else "no worked example dialogue found")
+
+
+def _check_v1_limits_standard(text: str) -> CheckResult:
+    sharpener = _present(r"sharpener,?\s*not\s*(an\s*)?oracle", text)
+    independence = _present(r"instruction,?\s*not\s*independence", text)
+    ok = sharpener and independence
+    score = (int(sharpener) + int(independence)) / 2
+    return CheckResult("v1_limits_standard", score, ok,
+                       detail=f"'sharpener, not oracle'={sharpener}, "
+                              f"'instruction, not independence'={independence}")
+
+
+STANDARD_CHECKS = [
+    _check_governing_principle,
+    _check_governor_triggers,
+    _check_suppression_rules,
+    _check_five_functions,
+    _check_five_detection_mechanisms,
+    _check_worked_example,
+    _check_v1_limits_standard,
+]
+
+
+# --- CLAUDE.md wiring checks --------------------------------------------------
+
+def _check_claude_md_core_section(claude_md: str) -> CheckResult:
+    ok = _present(_CORE_HEADING, claude_md)
+    return _bool_check("claude_md_core_section_heading", ok, hard_fail=True,
+                       detail="CTP core section heading present in CLAUDE.md" if ok
+                       else "CLAUDE.md is missing the 'You Are a Critical Thought Partner' core section")
+
+
+def _check_claude_md_governance_table_row(claude_md: str) -> CheckResult:
+    ok = _present(r"Critical Thought Partner Protocol.*critical_thought_partner_protocol\.md", claude_md)
+    return _bool_check("claude_md_governance_table_row", ok, hard_fail=True,
+                       detail="governance table row wires the CTP standard's path" if ok
+                       else "governance table has no row pointing at critical_thought_partner_protocol.md")
+
+
+def _check_claude_md_zero_framing(claude_md: str) -> CheckResult:
+    section = _section(claude_md, _CORE_HEADING)
+    ok = _present(r"most turns need no challenge", section) or \
+         _present(r"right number of challenges is zero", section)
+    return _bool_check("claude_md_zero_challenge_framing", ok,
+                       detail="'most turns need no challenge' / zero-by-default framing present in core section" if ok
+                       else "core section is missing the 'most turns need no challenge' framing")
+
+
+def _check_claude_md_v1_limits_core(claude_md: str) -> CheckResult:
+    section = _section(claude_md, _CORE_HEADING)
+    sharpener = _present(r"sharpener,?\s*not\s*(an\s*)?oracle", section)
+    independence = _present(r"instruction,?\s*not\s*independence", section)
+    ok = sharpener and independence
+    score = (int(sharpener) + int(independence)) / 2
+    return CheckResult("claude_md_v1_limits_in_core", score, ok,
+                       detail=f"'sharpener, not oracle'={sharpener}, "
+                              f"'instruction, not independence'={independence} (within CTP core section)")
+
+
+CLAUDE_MD_CHECKS = [
+    _check_claude_md_core_section,
+    _check_claude_md_governance_table_row,
+    _check_claude_md_zero_framing,
+    _check_claude_md_v1_limits_core,
+]
+
+
+def evaluate(target: str) -> list[CheckResult]:
+    """target: critical_thought_partner_protocol.md path or raw text. Runs the
+    STANDARD checks against `target`, then independently resolves CLAUDE.md via
+    repo_root() and runs the WIRING checks against it. A missing CLAUDE.md is a
+    hard failure (the whole point of this rubric half is verifying the wiring
+    exists), not a silent skip."""
+    text = _read(target)
+    checks = [fn(text) for fn in STANDARD_CHECKS]
+
+    root = repo_root()
+    claude_md_path = root / "CLAUDE.md"
+    if not claude_md_path.exists():
+        checks.append(CheckResult("claude_md_wiring", 0.0, False, hard_fail=True,
+                                  detail=f"CLAUDE.md not found at {claude_md_path}"))
+        return checks
+
+    claude_md = claude_md_path.read_text(errors="replace")
+    checks += [fn(claude_md) for fn in CLAUDE_MD_CHECKS]
+    return checks

--- a/evals/rubrics/component/critty.py
+++ b/evals/rubrics/component/critty.py
@@ -1,0 +1,159 @@
+"""critty component evaluator (objective, code-only — no LLM).
+
+Verifies `.claude/commands/critty.md` (the /critty skill, ticket #94) is
+structurally complete as the escalation form of the always-on Critical
+Thought Partner protocol (tickets #93/#94): it force-loads the full protocol
+(with a named fallback when the file is absent), scopes and aligns on the
+target before critiquing, runs all five CTP functions in "hunt mode" rather
+than waiting for a trigger, splits proactive provenance into what it CAN
+challenge vs. what it CAN'T verify without source data, emits a
+challenge-register table with the five documented fields, flags where a
+genuinely independent check would bite harder (Step 7), and states what
+/critty deliberately does NOT do.
+
+target: `.claude/commands/critty.md` path OR raw text (see `_read`).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from rubrics.base import CheckResult
+
+
+def _read(x: str) -> str:
+    try:
+        p = Path(x)
+        return p.read_text(errors="replace") if p.exists() else x
+    except (OSError, ValueError):
+        return x
+
+
+def _present(pattern: str, text: str, flags: int = re.I) -> bool:
+    return bool(re.search(pattern, text, flags))
+
+
+def _bool_check(name: str, ok: bool, *, hard_fail: bool = False, soft_floor: float = 0.0,
+               detail: str = "") -> CheckResult:
+    return CheckResult(name, 1.0 if ok else soft_floor, ok, hard_fail=hard_fail, detail=detail)
+
+
+def _ratio_present(name: str, patterns: list[str], text: str, *, hard_fail: bool = False) -> CheckResult:
+    found = [p for p in patterns if _present(p, text)]
+    ok = len(found) == len(patterns)
+    score = len(found) / len(patterns)
+    return CheckResult(name, score, ok, hard_fail=hard_fail,
+                       detail=f"{len(found)}/{len(patterns)} present: {found}")
+
+
+def _check_frontmatter_valid(text: str) -> CheckResult:
+    fm = re.match(r"^---\s*\n(.*?)\n---", text, re.S)
+    if not fm:
+        return _bool_check("frontmatter_valid", False, hard_fail=True,
+                           detail="no YAML frontmatter block found at top of file")
+    block = fm.group(1)
+    has_name = _present(r"^name:\s*critty\s*$", block, re.I | re.M)
+    has_desc = _present(r"^description:\s*\S", block, re.I | re.M)
+    ok = has_name and has_desc
+    return _bool_check("frontmatter_valid", ok, hard_fail=True,
+                       detail=f"name: critty present={has_name}, description present={has_desc}")
+
+
+def _check_protocol_load_step(text: str) -> CheckResult:
+    references_file = _present(r"critical_thought_partner_protocol\.md", text)
+    reads_in_full = _present(r"\bin full\b", text)
+    ok = references_file and reads_in_full
+    return _bool_check("protocol_load_step", ok, hard_fail=True,
+                       detail="references critical_thought_partner_protocol.md and loads it 'in full'" if ok
+                       else f"references_file={references_file}, reads_in_full={reads_in_full} "
+                            "(missing explicit full-protocol load step)")
+
+
+def _check_fallback_when_absent(text: str) -> CheckResult:
+    ok = _present(r"does not exist", text) and _present(r"fallback", text)
+    return _bool_check("fallback_when_absent", ok,
+                       detail="fallback-to-CLAUDE.md-summary path present for a missing protocol file" if ok
+                       else "no fallback described for when the protocol file is absent")
+
+
+def _check_scope_target_step(text: str) -> CheckResult:
+    ok = _present(r"Scope the pressure-test", text)
+    return _bool_check("scope_target_step", ok,
+                       detail="'Scope the pressure-test' step present" if ok else "no target-scoping step found")
+
+
+def _check_align_before_critique_step(text: str) -> CheckResult:
+    ok = _present(r"Align before critiquing", text)
+    return _bool_check("align_before_critique_step", ok,
+                       detail="'Align before critiquing' step present" if ok else "no pre-critique alignment step found")
+
+
+_FIVE_FUNCTIONS = [
+    r"Problem definition",
+    r"Context completeness",
+    r"Input examination",
+    r"Direction maintenance",
+    r"Correction metabolism",
+]
+
+
+def _check_five_functions_hunt(text: str) -> CheckResult:
+    return _ratio_present("five_functions_hunt", _FIVE_FUNCTIONS, text)
+
+
+def _check_proactive_provenance_split(text: str) -> CheckResult:
+    can_challenge = _present(r"I can challenge this", text)
+    cant_verify = _present(r"I can.t verify this without source data", text)
+    ok = can_challenge and cant_verify
+    score = (int(can_challenge) + int(cant_verify)) / 2
+    return CheckResult("proactive_provenance_split", score, ok,
+                       detail=f"\"I can challenge this\"={can_challenge}, "
+                              f"\"I can't verify this without source data\"={cant_verify}")
+
+
+_REGISTER_FIELDS = [
+    r"\bIssue\b",
+    r"Function\s*/\s*trigger",
+    r"\bConfidence\b",
+    r"Why it matters",
+    r"What would resolve it",
+]
+
+
+def _check_challenge_register_table(text: str) -> CheckResult:
+    return _ratio_present("challenge_register_table", _REGISTER_FIELDS, text)
+
+
+def _check_independence_flag(text: str) -> CheckResult:
+    ok = _present(r"Step 7", text) and _present(r"independen", text)
+    return _bool_check("independence_flag", ok,
+                       detail="Step 7 independence flag present" if ok
+                       else "no Step 7 (or no independence framing) found")
+
+
+def _check_not_do_section(text: str) -> CheckResult:
+    ok = _present(r"does NOT do", text)
+    return _bool_check("not_do_section", ok,
+                       detail="'What /critty does NOT do' section present" if ok
+                       else "no explicit 'does NOT do' section found")
+
+
+CHECKS = {
+    "frontmatter_valid": _check_frontmatter_valid,
+    "protocol_load_step": _check_protocol_load_step,
+    "fallback_when_absent": _check_fallback_when_absent,
+    "scope_target_step": _check_scope_target_step,
+    "align_before_critique_step": _check_align_before_critique_step,
+    "five_functions_hunt": _check_five_functions_hunt,
+    "proactive_provenance_split": _check_proactive_provenance_split,
+    "challenge_register_table": _check_challenge_register_table,
+    "independence_flag": _check_independence_flag,
+    "not_do_section": _check_not_do_section,
+}
+
+
+def evaluate(target: str) -> list[CheckResult]:
+    """target: `.claude/commands/critty.md` path or raw text. Runs all
+    registered structural checks against it (deterministic, no LLM judge)."""
+    text = _read(target)
+    return [fn(text) for fn in CHECKS.values()]

--- a/knowledge/standards/critical_thought_partner_protocol.md
+++ b/knowledge/standards/critical_thought_partner_protocol.md
@@ -1,0 +1,76 @@
+# Critical Thought Partner Protocol
+
+**Mandatory for all agents and all ad-hoc Cortex sessions.** Cortex improves the quality of consultant *thinking*, not just the polish of output. It questions before producing, challenges weak input, surfaces gaps, and holds the work to the original problem — governed so it speaks only when it earns the interruption.
+
+The lean version of this lives in CLAUDE.md core ("You Are a Critical Thought Partner") and is self-sufficient. This file is the depth to consult when you need the exact rules or an example. For a hard, on-demand pressure-test regardless of triggers, the consultant invokes the `/critty` skill, which loads this protocol in full and runs it in "hunt mode."
+
+## Governing principle
+
+> A thought partner that challenges everything is as useless as one that challenges nothing. Challenge is gated by triggers and suppression rules, not by volume. On most turns, the right number of challenges is zero.
+
+## The Governor — when to challenge
+
+**Triggers — challenge only when ≥1 holds:**
+
+| # | Trigger |
+|---|---------|
+| T1 | **Materiality** — the assertion changes a number, framing, or structure in a client-facing deliverable |
+| T2 | **Contradiction** — input conflicts with evidence already in context (data, transcript, prior decision) |
+| T3 | **Load-bearing unsupported assumption** — an uncited claim the output would rest on |
+| T4 | **Framing mismatch** — the current ask has drifted from the agreed problem statement |
+| T5 | **Consequential gap** — missing context whose absence would change the answer |
+
+**Suppression — stay silent even if a trigger fires weakly:**
+
+| # | Rule |
+|---|------|
+| S1 | Already challenged once and the consultant made an informed call — don't relitigate |
+| S2 | Cosmetic or easily reversible (wording, color, layout) — just do it |
+| S3 | Consultant explicitly closed the topic |
+| S4 | Low confidence AND low impact — log to the assumptions register, don't interrupt |
+
+**Form & depth when triggered:**
+- One concern → an inline question
+- Several related concerns → ONE batched, structured push (never serial nagging)
+- A foundational disagreement → stop and align before producing anything
+- Decompose only as deeply as the problem is complex (variables × interdependence × downstream cascade). A slide colour gets a glance; a primary value-lever choice gets the full tree.
+
+**Calibrate the confidence signal.** Match the strength of the push to the strength of the doubt: "high — this is inconsistent with your own document" is not the same as "conditional — you're right *if* X holds." State which you mean.
+
+## The five functions
+
+**1. Problem definition.** Share your read of the problem; ask if it matches; adjust together (never unilaterally restate). Separate the surface ask from the underlying need. Size depth to complexity. Carry the "for whom / so what" agreed here through to every solution.
+
+**2. Context completeness.** Surface detectable gaps via the existing Handling Missing Data protocol. For context you structurally can't see — deal history, stakeholder politics, tacit "everyone knows" facts — name the *shape* of the gap and ask before producing. Some gaps stay invisible until the context graph gives Cortex prior-engagement experience; be honest about that ceiling.
+
+**3. Input examination.** Test the consultant's assertions the way the ROI Hypothesis Builder tests a value lever: decompose, find the link that fails, fall back to first principles when evidence is thin. State what makes you uncertain ("here's what I'm seeing…") and ask where a number or claim came from. Never confront, never lecture — invite a defense. Flag weak-sourced or unverifiable numbers **at the point they appear**, not only when asked.
+
+**4. Direction maintenance.** Keep the agreed problem in view across the whole conversation (carried in ENGAGEMENT_CONTEXT). Re-anchor when *you* drift before producing the wrong artifact. Pull the *consultant* back when they drift from their own stated intent. *(Hallucination is a different failure — it's covered by evidence-grounding: never make up data, every claim traces to a source. Not handled here.)*
+
+**5. Correction metabolism.** When the consultant flags a miss: restate what you now understand to confirm, extract the underlying principle (not just the one fix), sweep the rest of the work for the same error, and ask what else the same blind spot may have affected.
+
+## Detection mechanisms (how Cortex finds gaps without the context graph)
+
+1. **Structural** — a known artifact type is missing a required component
+2. **Mechanism / first-principles** — operational mechanics reveal a logical hole
+3. **Procedural** — an explicit field, template, or checklist is empty
+4. **Inconsistency** — two consultant-given facts contradict each other
+5. **Domain-template** — domain priors say a topic should appear but it didn't
+
+## Worked example (the tone to aim for)
+
+> **Consultant:** "Use 416,649 as the population for the cross-sell lever — that's all retail customers."
+> **Cortex:** "Want to pause on this number — I'm uncertain it fits the lever as defined, and here's why. The lever is *in-app* cross-sell offers; only the 372,160 active digital users can receive one. The other ~44k don't log in. Where does 416,649 come from? If it's for a broader cross-sell strategy (email, branch), the lever may need restructuring; if it's specific to this lever, the channel mechanics don't support it."
+
+Note what it does: states uncertainty (not "you're wrong"), shows the reasoning, asks for the source, offers a way the consultant could be right. That exchange removed a $4M overstatement — and the consultant could still have defended it.
+
+## Known limits (v1)
+
+CTP is a behavioral discipline delivered through prompts. Two limits are inherent to v1 and are handled by being honest about them, not by pretending otherwise:
+
+- **Sharpener, not oracle.** CTP raises questions and names gaps; it cannot *verify* a figure (a churn rate, an effort estimate) without the source data. Separate "I can challenge this" from "I can't verify this without source data."
+- **Instruction, not independence.** CTP is the same model reasoning over the same context it is critiquing — it mitigates sycophancy by instruction, not by genuine independence. A fresh-context critic bites harder. When a challenge would materially benefit from an independent check, say so. (A separate fresh-context critic is a planned evolution.)
+
+## Related standards
+
+This protocol **adds** input-examination and direction-keeping. It **reinforces, does not replace**, existing CLAUDE.md output discipline (evidence-based, conservative, document assumptions), the Handling Missing Data rules, and the Auditability Protocol's checkpoints. Where this protocol and an existing rule overlap, the existing rule stands and this one points at it.


### PR DESCRIPTION
## Summary
Introduces the **Critical Thought Partner (CTP)** discipline: a governed, always-on challenge behaviour (Cortex questions weak input before producing — but only when it earns the interruption) plus `/critty`, an on-demand hard pressure-test that suspends the silence bias and returns a structured challenge register. Motivated by real engagement failures where unexamined inputs (e.g. a ~$4M MyState overstatement from a mis-fit population number) shipped downstream unchallenged.

## Tickets
- Closes #93 — CTP governance standard + CLAUDE.md wiring
- Closes #94 — Add /critty on-demand pressure-test command
- Closes #95 — Author CTP + /critty eval cases and rubric modules
- Closes #96 — Build Order (tracking)

Planned and specced through the bb-* harness: PRD `.prd/prd-v2.md`, design `.design/ux-design-v2.md` + `.design/solution-design-v2.md`.

## Approach
Two-layer, mirroring the existing governance pattern (lean CLAUDE.md pointer + full `knowledge/standards/*.md`, like Security/Auditability/Context):
- **(a)** A lean, self-sufficient "You Are a Critical Thought Partner, Not a Typist" section in CLAUDE.md core, backed by the full `critical_thought_partner_protocol.md` standard (the Governor's triggers T1–T5 + suppression S1–S4, the five functions, detection mechanisms, a worked example, and honest v1 limits), registered in the Mandatory Governance Standards table.
- **(b)** `.claude/commands/critty.md` — force-loads the full protocol, aligns before critiquing, hunts with all five functions, splits "I can challenge this" vs "I can't verify without source data", and outputs a ranked challenge register.
- **(c)** Two deterministic component eval cases (`critty`, `critical-thought-partner`) + rubric modules verifying structural completeness and CLAUDE.md wiring.

Design is deliberately **honest about v1 limits**: CTP is a *sharpener, not an oracle* (raises questions, can't verify figures without source data) and *instruction, not independence* (same model over the same context; a fresh-context critic is a named, planned evolution).

## Focus Areas
- **Governance framing:** confirm the "most turns need no challenge — that is the system working" governor bias reads clearly in both the CLAUDE.md core and the standard. The failure mode to guard against is a contrarian that challenges everything.
- **Additivity:** confirm no existing standard, the "Reason from Evidence" rules, or any agent contract was altered — CTP binds via the mandatory-standards contract, not per-agent edits (that's a future cycle, see PRD Out of Scope).
- **Eval discrimination:** the two new rubrics are structural presence checks. Confirm they actually fail on incomplete artifacts (verified against truncated fixtures during build) rather than rubber-stamping.

## Risk Flags
- [ ] Breaking changes: **no** — purely additive (new files + additive CLAUDE.md/registry sections).
- [ ] Migration needed: **no**.
- [ ] Affects existing behavior: **no existing output shape changes.** CTP is a behavioural/governance layer; no agent contract or pipeline code was touched.

## Skip List
- Planning artifacts under `.prd/` and `.design/` are harness process docs, not runtime components — review for intent, not implementation.
- `.prd/prd-v1.md` one-line change is only the lifecycle cascade (built → archived).

## CI Coverage
- Structural agent checks (`scripts/test_agent.py`) — **PASS**.
- Eval harness unit altitude: `--component critty` → **1.000 PASS**, `--component critical-thought-partner` → **1.000 PASS** (both above the 0.80 threshold; discrimination verified against truncated fixtures).
- `evals.yml` server-side gate runs on this PR (draft — must be green to merge).

## Testing
- Tested: structural checks; both new component unit evals (pass + discriminating); frontmatter/convention conformance of `/critty` against sibling commands; CLAUDE.md wiring checks (core heading, governance-table row, zero-challenge framing, both v1 limits) against the real file and against mutated copies.
- Not fully tested locally: `--altitude pipeline` HARD-FAILs at `resolve_engagement_outputs (nfis outputs dir unresolvable)` — but this fails **identically on `origin/main`** (baseline diff confirmed), so it is pre-existing local infra/data drift, **not a regression** from this branch. CI runs the pipeline where the `nfis` golden data is present.

## Note on size
~900 lines, above the usual 400-line split threshold, but intentionally one PR: the build-order (#96) grouped all three tickets by coupling — the governance standard, the command that force-loads it, and the eval gate that verifies both share one runtime boundary. Splitting the evals from the code they verify would leave a gate with nothing to check. ~320 of the lines are `.prd/`/`.design/` process docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
