### PR TITLE
feat(skill-first): PR 1 — contract infrastructure (composer, artifact gates, mode checks)

### DIFF
--- a/.design/solution-design-v3.md
+++ b/.design/solution-design-v3.md
@@ -1,0 +1,191 @@
+---
+version: 3
+prd: prd-v3.md
+status: draft
+date: 2026-07-24
+author: Mariam Titus George
+previous: solution-design-v1.md
+---
+
+<!-- Version note: v2 is intentionally skipped — PR #97 (feat/ctp-critty) carries
+     .design/*-v2.md. See prd-v3.md for the same convention. -->
+
+# Solution Design v3 — Skill-First Phase 1: Mode-Scoped Agent Contracts
+
+## Component Structure
+
+```
+.claude/agents/                          — MODIFIED (10 files, one ticket each)
+  discovery-transcript-interpreter.md    — + ## Modes (standalone, pipeline); PII round-trip contract explicit
+  journey-builder.md                     — + ## Modes (standalone, pipeline)
+  market-context-researcher.md           — + ## Modes (standalone, pipeline)
+  capability-assessment.md               — + ## Modes (standalone, pipeline)
+  roi-hypothesis-builder.md              — + ## Modes (standalone, pipeline)
+  benchmark-librarian.md                 — + ## Modes (standalone, pipeline) — FIRST extraction (lowest risk)
+  roi-financial-modeler.md               — + ## Modes (standalone, pipeline, excel-source); capping moves out
+  roadmap-prioritization.md              — + ## Modes (standalone, pipeline)
+  narrative-assembler.md                 — + ## Modes (standalone, pipeline-shard, pipeline-report, html-partial) — LAST (most complex)
+  knowledge-harvester.md                 — + ## Modes (pipeline, backfill)
+
+scripts/
+  orchestrate.py                         — MODIFIED: gains parse_agent_modes() + compose_prompt(agent, mode, params);
+                                           per-agent f-string prompt bodies deleted as each agent is extracted;
+                                           legacy inline path retained for not-yet-extracted agents (mixed state)
+  artifact_boundary.py                   — NEW: the artifact gates, shared by pipeline and standalone paths
+                                             cap_roi_config(path)      (moved from orchestrate._validate_roi_config)
+                                             deanonymize_dir(dir)      (moved from orchestrate step logic)
+                                             validate_outputs(dir, t)  (thin wrapper over validate_engagement_outputs.sh)
+  test_agent.py                          — MODIFIED: structural check — each extracted agent declares its
+                                           expected mode sections; missing/renamed mode fails
+
+.claude/commands/
+  build-roi.md                           — MODIFIED: after modeler runs, invoke artifact_boundary.cap_roi_config
+  generate-roi-excel.md                  — MODIFIED: refuses/flags an uncapped roi_config.json
+
+tests/quality_metrics.yaml               — MODIFIED: adds mode-section requirement for the 10 extracted agents
+
+evals/
+  registry.yaml                          — MODIFIED: + standalone-capping parity case (golden: capped config;
+                                           negative: uncapped config must fail); existing rows unchanged
+  goldens/roi_config_overcap.json        — NEW negative fixture
+```
+
+No new component *types*: contracts live inside the existing agent `.md` files; `require-harness.py`, `test-agents.yml`, and the eval registry continue to see one file per agent.
+
+## Data & Contract Model
+
+### The mode section (the heart of the change)
+
+Each agent `.md` gains one `## Modes` section containing one `### Mode: <name>` block per supported invocation. Structured facts go in a fenced YAML block (parsed by the composer); behavior stays prose (read by the model):
+
+```markdown
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes().
+     An invocation receives ONLY: core identity (everything above ## Modes)
+     + its selected mode block. Other modes are stripped. -->
+
+### Mode: standalone   <!-- default when no phase directive present -->
+```yaml
+inputs:
+  required: []
+  optional:
+    - outputs/evidence_register.md
+    - outputs/pain_points.md
+degraded: ask-inline        # ask-inline | proceed-without | refuse
+knowledge:                  # exhaustive whitelist — replaces "read the domain pack"
+  - knowledge/domains/{domain}/benchmarks.md
+  - knowledge/standards/capability_taxonomy_{domain}.md
+outputs:
+  - outputs/capability_assessment.md
+checkpoint: interactive     # interactive | file | none
+gates: []                   # artifact_boundary functions to run on outputs
+```
+Prose: behavior notes specific to this mode.
+
+### Mode: pipeline
+```yaml
+params: [outputs_dir, domain]   # runtime values injected by the composer
+inputs:
+  required:
+    - "{outputs_dir}/evidence_register.md"
+degraded: refuse            # pipeline never silently skips a required artifact
+knowledge: [...]
+outputs:
+  - "{outputs_dir}/capability_assessment.md"
+checkpoint: file            # CHECKPOINT_capability.md / _APPROVED.md protocol
+phases: single              # single | two-phase
+gates: []
+```
+```
+
+**Rationale for the hybrid YAML-in-markdown shape:** the composer needs machine-readable inputs/outputs/whitelists (it validates required inputs before spending an agent run, and strips unselected modes); the model needs prose for judgment behavior. Pure prose is unparseable; pure YAML can't carry methodology. The YAML keys above are the complete set — no speculative fields.
+
+### Composer contract (orchestrate.py)
+
+```
+compose_prompt(agent_name, mode, params) -> system_prompt
+  1. parse .claude/agents/<agent_name>.md
+  2. core = content above ## Modes (frontmatter stripped)
+  3. block = the selected ### Mode section; error if absent
+  4. substitute params into {placeholders}; params carry VALUES only
+     (paths, domain) — never instructions
+  5. return core + block + params table
+
+run_agent(agent_name, mode=..., params=...)   # extracted agents
+run_agent(agent_name, prompt=...)             # legacy, during rollout only
+```
+
+### Artifact gate contract (scripts/artifact_boundary.py)
+
+| Function | Input | Output | Behavior |
+| --- | --- | --- | --- |
+| `cap_roi_config(path)` | roi_config.json | same file, capped + gate report dict | Identical math to today's `_validate_roi_config` (impact cap 0.60, segment ROI ranges, curve-adjusted recompute). Moved, not rewritten. |
+| `deanonymize_dir(dir)` | outputs dir + `.pii_mapping.json` | outputs de-anonymized, report | Missing mapping → loud "NOT client-ready" flag, never silent |
+| `validate_outputs(dir, type)` | outputs dir | pass/fail + missing list | Wraps existing `validate_engagement_outputs.sh` |
+
+Both orchestrate.py steps and skills (`/build-roi`, `/generate-roi-excel`) call these — one implementation, two callers.
+
+## Agent / Pipeline Steps
+
+No new agents, no new DAG steps. Changed invocations only:
+
+| Name | Type | Input | Output | Purpose |
+| --- | --- | --- | --- | --- |
+| `compose_prompt` | pipeline helper | agent .md + mode + params | system prompt | Single source of truth for what an agent is told |
+| `parse_agent_modes` | pipeline helper | agent .md | mode dict | Parse + validate mode sections |
+| `cap_roi_config` | artifact gate | roi_config.json | capped config | Same guarantee for pipeline and standalone |
+| `deanonymize_dir` | artifact gate | outputs dir | client-ready outputs | Ends pipeline-only de-anonymization |
+| `validate_outputs` | artifact gate | outputs dir | pass/fail | Completeness check callable outside the pipeline |
+| 10 × agent invocation | agent (modified) | per mode contract | per mode contract | Extracted one at a time, order below |
+
+**Extraction order (risk ascending, one ticket each):** benchmark-librarian → knowledge-harvester → capability-assessment → market-context-researcher → roi-hypothesis-builder → journey-builder → roadmap-prioritization → roi-financial-modeler (with the capping move) → discovery-transcript-interpreter (PII round-trip — needs the most care) → narrative-assembler (4 modes, most complex, last).
+
+## Integration Points
+
+| Existing component / step | How it's touched | Risk |
+| --- | --- | --- |
+| orchestrate.py step functions | Inline prompt f-strings replaced by composer calls, one agent at a time; mixed state supported throughout | Medium — mitigated by per-agent pipeline-eval gate |
+| Checkpoint protocol (CHECKPOINT_*.md / _APPROVED.md) | Unchanged; mode YAML only *names* which protocol applies | Low |
+| `_validate_roi_config` in orchestrate.py | Moved to artifact_boundary.py; orchestrate imports it; `/build-roi` + `/generate-roi-excel` gain the same call | Medium — behavior must be move-not-rewrite; parity eval case guards it |
+| PII round-trip (anonymize → run → de-anonymize) | Anonymize side untouched (hook + script); de-anonymize side moves to artifact_boundary | High — extracted second-to-last; discovery ticket includes explicit PII regression checks |
+| `.claude/agents/*.md` descriptions contradicting injected prompts | Contradictions resolved during extraction; default rule in Technical Decisions | Medium — every resolution logged in ticket + PR |
+| evals/registry.yaml component rows | Unchanged rows must stay ≥ 0.80; new parity case added | Low |
+| test_agent.py + quality_metrics.yaml | Gain mode-structure checks; must land in the same PR as the first extraction or CI contradicts itself | Medium |
+| Inspire subsystem, bb-* harness, hooks | Untouched | — |
+
+## Technical Decisions
+
+**Decision 1: Modes live inside the agent `.md`, parsed by the composer.**
+**Alternatives:** separate contract files per agent; a central contracts.yaml.
+**Rationale:** Owner decision (2026-07-24): don't change what the harness treats as a component. One file per agent keeps require-harness, test-agents.yml, and the eval registry untouched.
+**Trade-offs:** orchestrate.py parses markdown; standalone Task-tool invocations load the whole file including unselected modes (see Decision 6).
+
+**Decision 2: Hybrid contract — YAML block for facts, prose for behavior.**
+**Alternatives:** all prose (status quo, unparseable); all YAML (can't carry methodology).
+**Rationale:** The composer must validate inputs and strip modes mechanically; the model needs judgment guidance. Each format does what it's good at.
+**Trade-offs:** Two syntaxes in one file; the structural check in test_agent.py keeps the YAML honest.
+
+**Decision 3: Mixed-state rollout — legacy inline prompts coexist with extracted modes.**
+**Alternatives:** flag-day migration of all 10 agents in one PR.
+**Rationale:** Per-agent revert (PRD rollback plan) is only possible if unextracted agents keep working untouched. Also matches the eval gate cadence: pipeline green between every extraction.
+**Trade-offs:** orchestrate.py temporarily carries both paths; acceptable because the end state deletes the legacy path.
+
+**Decision 4: Contradiction-resolution default — the injected prompt wins for pipeline modes; the `.md` wins for standalone; ambiguity escalates to the Architect.**
+**Alternatives:** always trust the `.md`; always trust the script; decide ad hoc.
+**Rationale:** The injected prompts are what production has actually been running — pipeline behavior is *defined* by them today. The `.md`'s standalone descriptions are the only spec standalone mode ever had. Anything genuinely ambiguous is a product call, not an implementation call.
+**Trade-offs:** Some `.md` prose that was aspirational-but-never-run gets overwritten by production reality; the log makes each such loss visible and reversible.
+
+**Decision 5: Artifact gates as plain Python functions in one module, called by both paths.**
+**Alternatives:** duplicate the logic into skills; make gates an agent; hook-based enforcement.
+**Rationale:** These are deterministic checks (capping math, placeholder scans, file presence) — exactly what should NOT be an LLM. One module, two callers ends the pipeline/standalone guarantee gap with the least machinery.
+**Trade-offs:** Skills invoke them via Bash — a convention, not an enforcement. Hook-level enforcement is a Phase 2 (governance tiering) question, deliberately not decided here.
+
+**Decision 6: Standalone (Task-tool) invocations tolerate loading all modes; the compactness budget is the mitigation.**
+**Alternatives:** a launcher that pre-strips modes for standalone use; splitting files (rejected — Decision 1).
+**Rationale:** The harness loads whole agent files; we can't strip per-invocation there. Mode blocks are contracts (~20–40 lines each, 2–4 modes per agent), not methodology — the file-size budget is: no agent file grows more than ~20%, and extraction should *shrink* the largest ones by deleting duplicated/contradictory prose.
+**Trade-offs:** A standalone run carries a few hundred stray tokens of other modes' YAML. Negligible against the turns/knowledge-loading costs this design removes.
+
+**Decision 7: Extraction order is risk-ascending with the PII agent second-to-last and the assembler last.**
+**Alternatives:** DAG order (discovery first); alphabetical; all-parallel.
+**Rationale:** Learn the extraction mechanics on benchmark-librarian (small, already standalone-friendly) where a mistake is cheap; hit the PII round-trip and the 4-mode assembler after the pattern is proven ×8.
+**Trade-offs:** The highest-value agents are extracted last; acceptable because every extraction lands value independently.

--- a/.design/ux-design-v3.md
+++ b/.design/ux-design-v3.md
@@ -1,0 +1,129 @@
+---
+version: 3
+prd: prd-v3.md
+status: draft
+date: 2026-07-24
+author: Mariam Titus George
+previous: ux-design-v1.md
+---
+
+<!-- Version note: v2 is intentionally skipped — PR #97 (feat/ctp-critty) carries
+     .design/*-v2.md. See prd-v3.md for the same convention. -->
+
+# UX Design v3 — Skill-First Phase 1: Mode-Scoped Agent Contracts
+
+There is no visual UI in this change. The "users" are (a) consultants invoking an agent standalone, (b) the orchestrator invoking the same agent inside the pipeline, and (c) the developer performing each extraction. The UX is the invocation experience: what each caller must provide, what happens when inputs are missing, and what guarantees hold on the way out.
+
+## User Flows
+
+### Flow 1 — Consultant invokes an agent standalone (the flow this PRD makes real)
+
+```
+Consultant invokes agent/skill (no phase directive)
+        │
+        ▼
+Agent resolves mode = standalone (its default mode section)
+        │
+        ▼
+Input check against the mode's declared inputs
+        │
+        ├──[all required inputs present]──▶ Full run per mode contract
+        │                                        │
+        │                                        ▼
+        │                              In-session consultant checkpoint
+        │                              (interactive — no CHECKPOINT_*.md
+        │                               handshake wait)
+        │                                        │
+        │                                        ▼
+        │                              Writes ONLY the mode's declared outputs
+        │
+        └──[required input missing]──▶ Degraded path per mode contract:
+                                       agent states what's missing, what it
+                                       can still produce, and asks the
+                                       consultant to supply the gap inline
+                                       (paste content / point at a file / skip)
+        │
+        ▼
+Artifact gates run on declared outputs where applicable
+(ROI capping for roi_config.json; validation + de-anonymization
+ when output lands in an engagement outputs/ dir)
+        │
+        ▼
+Consultant sees: outputs written + one-line gate report
+("roi_config.json: backbase_impact capped 0.72 → 0.60 on L3")
+```
+
+### Flow 2 — Orchestrator invokes the same agent (pipeline mode)
+
+```
+orchestrate.py step reaches agent N
+        │
+        ▼
+Composer: parse agent .md → select mode section named in the DAG
+(e.g. mode: pipeline) → strip all other mode sections
+        │
+        ▼
+System prompt = core identity + selected mode + runtime params
+(outputs_dir, domain, engagement paths — values only, no instructions)
+        │
+        ▼
+Agent runs the mode contract: file checkpoint protocol
+(CHECKPOINT_x.md → _APPROVED.md), declared outputs only
+        │
+        ▼
+Same artifact gates as Flow 1 — now invoked by the orchestrator
+at the same boundary, not as private step logic
+        │
+        ├──[gates pass]──▶ next DAG step
+        └──[gate caps/fails]──▶ logged to run output + checkpoint trail,
+                                identical treatment to standalone
+```
+
+### Flow 3 — Developer extracts one agent (repeated 10×)
+
+```
+Pick next agent in the extraction order
+        │
+        ▼
+Diff agent .md vs orchestrate.py's injected prompt(s) for that agent
+        │
+        ▼
+Resolve contradictions (log each resolution; escalate ambiguous
+calls to the Architect — never decide silently)
+        │
+        ▼
+Write mode sections into the .md; replace the f-string in
+orchestrate.py with a composer call (mode + params)
+        │
+        ▼
+Verify: test_agent.py → component eval ≥ 0.80 → pipeline eval ≥ 0.90
+        │
+        ├──[green]──▶ commit; next agent
+        └──[red, can't fix forward]──▶ revert this agent's commits;
+                                       legacy inline path still intact
+```
+
+## Screen & Component States
+
+No screens. The interactive component is the agent invocation itself:
+
+| State | Trigger | What the caller sees |
+| --- | --- | --- |
+| Mode resolved | Invocation starts | Which mode is running and why (directive present → named mode; absent → standalone) |
+| Inputs satisfied | All required inputs found | Normal run; no noise |
+| Degraded | Required input missing (standalone) | What's missing, what can still be produced, inline options to supply or skip |
+| Blocked | Required input missing (pipeline) | Step fails fast with the missing path — no silent skip of a required artifact |
+| Checkpoint pending | Mode reaches its checkpoint | Standalone: in-session question. Pipeline: CHECKPOINT_*.md written, waiting on _APPROVED.md |
+| Gated | Artifact gate modified/flagged an output | One-line report of exactly what was capped/fixed/flagged and why |
+| Done | Declared outputs written | List of files written — and nothing not declared by the mode |
+
+## Error States
+
+| Error | Cause | User-facing message | Recovery |
+| --- | --- | --- | --- |
+| Missing mode section | Agent .md lacks the mode the caller requested | `Agent <name> has no mode '<mode>'. Available: standalone, pipeline.` (CI preflight makes this unreachable in a merged state) | Developer adds the mode section; caller picks an available mode |
+| Required input absent (standalone) | Consultant invoked cold without upstream artifact | `<mode> needs <artifact>. I can proceed without it by <degraded behavior>, or paste/point me at it.` | Supply inline, point at file, or accept degraded output |
+| Required input absent (pipeline) | Upstream step failed or was skipped | Step error naming the missing path and the producing step | Re-run producing step (`--resume-from`) |
+| ROI config over cap | Modeled impact exceeds reasonableness bounds | `backbase_impact on <lever> capped <x> → 0.60; 5-yr ROI recomputed. See gate report.` | None needed — capped output is the deliverable; consultant can revisit lever assumptions |
+| De-anonymization mapping missing | Output in engagement dir but no `.pii_mapping.json` | `Outputs still contain placeholders — no PII mapping found. Deliverable is NOT client-ready.` | Run the anonymization round-trip or confirm placeholders are intended |
+| Checkpoint approval never arrives (pipeline) | `_APPROVED.md` not produced | Existing orchestrator timeout behavior — unchanged by this PRD | Consultant approves or run resumes in non-interactive mode |

--- a/.prd/prd-v1.md
+++ b/.prd/prd-v1.md
@@ -1,6 +1,6 @@
 ---
 version: 1
-status: built
+status: archived
 date: 2026-07-07
 author: Mariam Titus George
 previous: null

--- a/.prd/prd-v3.md
+++ b/.prd/prd-v3.md
@@ -1,0 +1,86 @@
+---
+version: 3
+status: draft
+date: 2026-07-24
+author: Mariam Titus George
+previous: prd-v1.md
+---
+
+<!-- Version note: v2 is intentionally skipped on this branch. PR #97 (feat/ctp-critty)
+     already carries .prd/prd-v2.md (Critical Thought Partner). Numbering this PRD v3
+     avoids an add/add merge conflict and keeps both change records intact. -->
+
+# PRD v3 — Skill-First Phase 1: Mode-Scoped Agent Contracts
+
+## 1. Problem
+
+Consultants use individual skills far more than the full pipeline — the 2026-07 engagement record (People's First Bank, Bank Australia, HNB, MyState) is almost entirely single-skill invocations, while the docs, agent definitions, and governance all assume the orchestrated pipeline. This mismatch has three concrete costs:
+
+1. **Split-brain contracts.** Each pipeline agent's real operating contract — which files to read and write, phase behavior, output discipline, knowledge whitelist — lives in `orchestrate.py`'s inline prompt strings, while the agent `.md` file describes a different (and in places contradictory) invocation model. Example: agent descriptions instruct Task-tool orchestration; the orchestrator injects a hard ban on it. Standalone invocations of the same agent get undefined behavior — the multi-mode agents (e.g. the assembler's shard / report / HTML-partial behaviors) are selected entirely by injected prompt text a standalone consultant never sends.
+2. **Orphaned safety logic.** ROI reasonableness capping, PII de-anonymization, and output validation run only inside the pipeline. A standalone `/build-roi` today produces uncapped numbers and never de-anonymizes — skill-first usage silently ships less defensible output than pipeline usage.
+3. **Unscoped context loading.** Blanket "read the domain pack" instructions make agents load knowledge files wholesale. The injected pipeline prompts already scope this per step; standalone runs don't, which costs minutes per invocation.
+
+If we don't solve this, consultants keep defaulting to raw Claude for anything lightweight (the documented adoption killer), and every future skill improvement has to be made twice — once in the `.md`, once in the orchestrator's copy.
+
+## 2. Solution
+
+Make each agent's `.md` file the single source of truth for its operating contract, expressed as **named mode sections** inside the existing file (no new file types — the harness, CI, and eval registry keep treating one file per agent as the component). Each mode section declares: required inputs and degraded behavior when missing, required outputs, knowledge-file whitelist, and phase/checkpoint behavior. `orchestrate.py` stops carrying private prompt copies and instead invokes agents with a mode name plus runtime parameters (paths, domain); an invocation loads only its mode's contract, so per-run context stays small even as files grow. Safety logic that currently exists only inside the pipeline (ROI capping, de-anonymization, output validation) moves to the artifact boundary as utilities invoked by whichever path produces or consumes the artifact — pipeline and standalone runs get identical guarantees.
+
+## 3. Scope
+
+| This PRD covers | This PRD does NOT cover |
+| --- | --- |
+| The 10 pipeline-invoked agents: discovery-transcript-interpreter, journey-builder, market-context-researcher, capability-assessment, roi-hypothesis-builder, benchmark-librarian, roi-financial-modeler, roadmap-prioritization, narrative-assembler, knowledge-harvester | Governance tiering (light vs engagement mode) — Phase 2 |
+| Extracting orchestrate.py's inline agent prompts into mode sections in the agent `.md` files, one agent at a time | Jobs-to-be-done front door / launcher — Phase 3 |
+| Resolving every contradiction between an agent `.md` and its injected prompt (each resolution logged, not silent) | Deprecated-file pruning, hardcoded-path fixes — Phase 3 |
+| Moving ROI reasonableness capping, de-anonymization, and output validation to artifact-boundary utilities shared by pipeline and standalone paths | The Ignite Inspire workshop subsystem (already Claude-orchestrated) |
+| Per-mode knowledge-file whitelists replacing blanket domain-pack reads | The bb-* harness, hooks, eval infrastructure |
+| orchestrate.py reduced to composer: DAG, checkpoints, PII round-trip, Python-only merge/assembly steps | Changing what the harness treats as a component (contracts stay inside agent `.md` files) |
+| Defined standalone (no-directive) behavior for each of the 10 agents, including degraded behavior when upstream artifacts are absent | New agents or new skills |
+
+## 4. Success Metrics
+
+| Metric | Target |
+| --- | --- |
+| Agent instruction text remaining in orchestrate.py | Zero — the script passes mode name + runtime params only |
+| Contradictions between agent `.md` and injected prompts | Zero remaining; every resolution decision logged in the change record |
+| Standalone invocation behavior | Each of the 10 agents produces its mode-defined outputs when invoked without the orchestrator, with defined degraded behavior on missing inputs |
+| Safety parity | Standalone ROI runs produce capped configs identical in treatment to pipeline runs; standalone outputs in engagement dirs get de-anonymization and validation |
+| Pipeline regression | Pipeline-altitude eval stays ≥ 0.90 after each agent's extraction (verified incrementally, not big-bang) |
+| Per-invocation context | Each mode's knowledge whitelist is explicit; no mode instructs a blanket domain-pack read |
+
+## 5. Eval Acceptance Criteria
+
+| Component | `evals/registry.yaml` cases | Threshold | Altitude |
+| --- | --- | --- | --- |
+| Each of the 10 extracted agents | Existing component row for that agent (code + judge checks, committed synthetic goldens) | 0.80 | unit |
+| Full agent chain | `pipeline` case (golden engagement, inter-agent contracts) | 0.90 | pipeline |
+| roi-financial-modeler + capping utility | Existing roi rows PLUS new case: an over-cap `roi_config.json` produced via the standalone path is capped identically to the pipeline path (golden: capped config; negative: uncapped config must fail) | 0.80 | unit |
+| Deliverables | `roi`, `assessment`, `report`, `deck` deliverable cases (now pointing at committed fixtures, gate in BLOCKING mode) | 0.80–0.85 | deliverable |
+
+- **Per-ticket verify:** every extraction ticket runs `scripts/test_agent.py` (structural), `run_experiment.py --component <agent> --altitude unit`, and `run_experiment.py --altitude pipeline`. A ticket is not done until all three pass. This is the core safety property of the whole PRD: extraction proceeds one agent at a time, and the pipeline gate must be green before the next agent starts.
+- **New eval cases authored in this work:** (a) the standalone-capping parity case above; (b) a structural check (registry preflight or `test_agent.py`) that each of the 10 agent files contains its declared mode sections, so a missing mode fails CI rather than producing undefined behavior.
+- **Downstream consumers:** yes, this change affects every downstream consumer by design — the pipeline-altitude experiment is the binding gate throughout.
+- **Precondition:** PR #92 (goldens re-pointed to committed fixtures + gate flipped to BLOCKING) must be merged to main before extraction tickets start; this PRD's verify story is meaningless against the old vacuous registry.
+
+## 6. Out of Scope
+
+- Governance tiering, per-skill `governance:` classification, hook changes, telemetry ping for light-tier runs (Phase 2 — separate PRD)
+- Front-door launcher, README/QUICKSTART inversion, deprecated-file deletion, duplicate roi-business-case-builder resolution, hardcoded `/Users/mayur@backbase.com` path fixes (Phase 3 — separate PRD)
+- Any change to Ignite Inspire agents, workshop templates, or the nested Inspire CLAUDE.md
+- Deprecating or replacing orchestrate.py — it survives as the recipe for full assessments
+- Changing checkpoint semantics, journal requirements, or telemetry format (Phase 2 decides those)
+
+## Dependencies & Risks
+
+| Dependency/Risk | Impact | Mitigation |
+| --- | --- | --- |
+| PR #92 unmerged (fixed goldens + BLOCKING gate) | Extraction tickets verify against a vacuous gate | Hard precondition: merge #92 first; this branch is stacked on it |
+| Contradiction resolution requires judgment (which behavior was intended: `.md` or injected prompt?) | Silent wrong calls change agent behavior undetected | Every resolution logged in the change record; component eval + pipeline eval must pass per agent; ambiguous cases escalated to the Architect rather than decided in-edit |
+| `evals.yml` check not yet marked Required in branch protection | BLOCKING job can fail while merge still proceeds | Repo admin (Mayur) marks the check Required; until then, treat a red evals job as merge-blocking by convention |
+| Mode sections grow agent files substantially | None at runtime if invocations stay mode-scoped; risk is only if an invocation loads the whole file | Contract rule: an invocation receives core identity + one mode section only; enforced by the composer and stated in each agent's contract preamble |
+| Open PR #97 also touches CLAUDE.md and `.prd/` | Merge conflicts | This PRD numbered v3 to avoid the known prd-v2 add/add conflict; CLAUDE.md untouched by this PRD (its skill-first rewrite is Phase 3) |
+
+## Rollback Plan
+
+Extraction is per-agent and incremental. Each agent's extraction is a self-contained change: if its component or pipeline eval goes red and can't be fixed forward, revert that agent's commits — the orchestrator's injected-prompt path for the remaining agents is untouched until their own extraction lands. No flag-day migration; orchestrate.py supports mixed state (extracted agents invoked by mode, unextracted agents via legacy inline prompts) for the duration of the rollout.

--- a/.prd/prd-v3.md
+++ b/.prd/prd-v3.md
@@ -1,6 +1,6 @@
 ---
 version: 3
-status: draft
+status: built
 date: 2026-07-24
 author: Mariam Titus George
 previous: prd-v1.md

--- a/scripts/artifact_boundary.py
+++ b/scripts/artifact_boundary.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""
+Artifact boundary gates — shared by the pipeline (orchestrate.py) and
+standalone skill callers (/build-roi, /generate-roi-excel, /publish).
+
+Three gates, one module, two callers:
+  - cap_roi_config(path)          ROI reasonableness gate (impact caps + benchmarks)
+  - deanonymize_dir(dir)          restore client names from .pii_mapping.json
+  - validate_outputs(dir, type)   thin wrapper over validate_engagement_outputs.sh
+
+This module MUST stay importable by plain python3 (3.9+): no claude_agent_sdk,
+no orchestrate.py imports (dependency direction is orchestrate -> artifact_boundary),
+no 3.10+ syntax.
+
+CLI (what skills call):
+    python3 scripts/artifact_boundary.py cap <roi_config.json>
+    python3 scripts/artifact_boundary.py deanon <engagement_or_outputs_dir>
+    python3 scripts/artifact_boundary.py validate <engagement_dir> [engagement_type]
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ─── Colors for terminal output (matches orchestrate.py style) ────────────────
+
+class C:
+    BOLD = "\033[1m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    CYAN = "\033[96m"
+    DIM = "\033[2m"
+    RESET = "\033[0m"
+
+
+def log(msg: str, color: str = ""):
+    ts = datetime.now().strftime("%H:%M:%S")
+    print(f"{C.DIM}{ts}{C.RESET} {color}{msg}{C.RESET}")
+
+
+# ─── ROI Reasonableness Gate (moved from orchestrate.py) ─────────────────────
+
+MAX_BACKBASE_IMPACT = 0.60
+
+# Segment benchmark ranges for ROI validation (from roi_calibrator.py)
+SEGMENT_ROI_RANGES = {
+    "Retail Banking": (100, 150),
+    "Wealth Management": (120, 200),
+    "Commercial Banking": (80, 140),
+    "SME Banking": (70, 130),
+    "Corporate Banking": (100, 150),
+    "Investing": (100, 150),
+}
+
+
+def _compute_5yr_roi(config: dict) -> Optional[float]:
+    """Compute 5-year ROI from config using curves (matching Excel logic)."""
+    groups = config.get('value_lever_groups', config.get('journeys', {}))
+    bl = config.get('backbase_loading', {})
+    impl_curve = bl.get('implementation_curve', [0.3, 0.7, 0.8, 1.0, 1.0])
+    eff_curve = bl.get('effectiveness_curve', [0.15, 0.35, 0.6, 0.85, 1.0])
+
+    # Sum steady-state annual benefit across all drivers
+    total_steady_state = 0
+    for group in groups.values():
+        for dtype in ('revenue_drivers', 'cost_drivers'):
+            for driver in group.get(dtype, {}).values():
+                baseline = driver.get('baseline_annual', 0)
+                bi = driver.get('inputs', {}).get('backbase_impact', {})
+                impact = bi.get('value', 0) if isinstance(bi, dict) else bi if isinstance(bi, (int, float)) else 0
+                total_steady_state += baseline * impact
+        # Add servicing analysis totals
+        sa = group.get('servicing_analysis')
+        if isinstance(sa, dict):
+            for channel in sa.values():
+                if isinstance(channel, dict):
+                    for task in channel.get('tasks', []):
+                        if isinstance(task, dict):
+                            total_steady_state += task.get('total_saved', 0)
+
+    # Apply curves year by year (matching Excel logic)
+    total_5yr_benefit = 0
+    for yr in range(5):
+        impl = impl_curve[yr] if yr < len(impl_curve) else 1.0
+        eff = eff_curve[yr] if yr < len(eff_curve) else 1.0
+        total_5yr_benefit += total_steady_state * impl * eff
+
+    # Sum investment
+    inv = config.get('investment', {})
+    total_investment = 0
+    for inv_type in ('license', 'implementation'):
+        inv_data = inv.get(inv_type, {})
+        if isinstance(inv_data, dict):
+            for yr_key in ('year_1', 'year_2', 'year_3', 'year_4', 'year_5'):
+                total_investment += inv_data.get(yr_key, 0)
+        elif isinstance(inv_data, (int, float)):
+            total_investment += inv_data
+
+    if total_investment <= 0:
+        return None
+
+    return (total_5yr_benefit - total_investment) / total_investment * 100
+
+
+def cap_roi_config(config_path) -> dict:
+    """Validate roi_config.json for unreasonable values. Caps impacts and warns.
+
+    Moved from orchestrate.py `_validate_roi_config` — math unchanged.
+    Writes the capped config back in place and returns a gate-report dict.
+    """
+    config_path = Path(config_path)
+    report = {
+        "gate": "cap_roi_config",
+        "config": str(config_path),
+        "exists": config_path.exists(),
+        "parse_error": None,
+        "warnings": [],
+        "modified": False,
+        "curve_roi": None,
+        "segment": None,
+        "benchmark_range": None,
+        "passed": False,
+    }
+    if not config_path.exists():
+        return report
+    try:
+        config = json.loads(config_path.read_text())
+    except Exception as e:
+        log(f"  ⚠ Could not parse roi_config.json: {type(e).__name__}", C.YELLOW)
+        report["parse_error"] = type(e).__name__
+        return report
+
+    warnings = []
+    modified = False
+    total_benefit = 0
+    client_revenue = config.get('bank_profile', {}).get('total_revenue', 0)
+
+    groups = config.get('value_lever_groups', config.get('journeys', {}))
+    for group_key, group in groups.items():
+        for driver_type in ('revenue_drivers', 'cost_drivers'):
+            for drv_key, driver in group.get(driver_type, {}).items():
+                bi = driver.get('inputs', {}).get('backbase_impact', {})
+                val = bi.get('value', 0) if isinstance(bi, dict) else bi if isinstance(bi, (int, float)) else 0
+                if isinstance(val, (int, float)) and val > MAX_BACKBASE_IMPACT:
+                    warnings.append(
+                        f"    {drv_key}: backbase_impact {val:.0%} → capped to {MAX_BACKBASE_IMPACT:.0%}"
+                    )
+                    if isinstance(bi, dict):
+                        bi['value'] = MAX_BACKBASE_IMPACT
+                    modified = True
+                baseline = driver.get('baseline_annual', 0)
+                impact = bi.get('value', 0.30) if isinstance(bi, dict) else bi if isinstance(bi, (int, float)) else 0.30
+                total_benefit += baseline * impact
+
+    # Cap scenario-level impacts
+    for sc_name, sc in config.get('scenarios', {}).items():
+        if not isinstance(sc, dict):
+            continue
+        for imp_key, imp_val in sc.get('backbase_impacts', {}).items():
+            if isinstance(imp_val, (int, float)) and imp_val > MAX_BACKBASE_IMPACT:
+                warnings.append(
+                    f"    Scenario '{sc_name}' impact '{imp_key}': {imp_val:.0%} → capped to {MAX_BACKBASE_IMPACT:.0%}"
+                )
+                sc['backbase_impacts'][imp_key] = MAX_BACKBASE_IMPACT
+                modified = True
+
+    # --- OVERESTIMATION CHECKS ---
+    investment = config.get('total_investment', 0)
+    if investment > 0 and total_benefit > 0:
+        five_yr_roi_simple = (total_benefit * 5 - investment) / investment * 100
+        if five_yr_roi_simple > 500:
+            warnings.append(
+                f"    5-year ROI (simple) = {five_yr_roi_simple:.0f}% — exceeds 500% threshold, review baselines"
+            )
+
+    if client_revenue > 0 and total_benefit > client_revenue * 0.05:
+        warnings.append(
+            f"    Total annual benefit ${total_benefit:,.0f} exceeds 5% of client revenue ${client_revenue:,.0f}"
+        )
+
+    # --- UNDERESTIMATION CHECK (NEW) ---
+    # Compute curve-adjusted ROI (matches Excel logic)
+    curve_roi = _compute_5yr_roi(config)
+    if curve_roi is not None:
+        # Detect segment
+        industry = config.get('industry', '').lower()
+        segment = "Retail Banking"  # default
+        for seg_name in SEGMENT_ROI_RANGES:
+            if seg_name.lower().replace(' ', '') in industry.replace(' ', '').lower():
+                segment = seg_name
+                break
+        if 'wealth' in industry:
+            segment = "Wealth Management"
+        elif 'invest' in industry:
+            segment = "Investing"
+        elif 'commercial' in industry:
+            segment = "Commercial Banking"
+        elif 'sme' in industry or 'small' in industry:
+            segment = "SME Banking"
+        elif 'corporate' in industry:
+            segment = "Corporate Banking"
+
+        low, high = SEGMENT_ROI_RANGES.get(segment, (60, 150))
+        log(f"  📊 Curve-adjusted 5-year ROI: {curve_roi:.0f}% (segment: {segment}, benchmark: {low}-{high}%)", C.CYAN)
+        report["curve_roi"] = curve_roi
+        report["segment"] = segment
+        report["benchmark_range"] = [low, high]
+
+        if curve_roi < low:
+            warnings.append(
+                f"    ⚠ ROI {curve_roi:.0f}% is BELOW {segment} benchmark range ({low}-{high}%). "
+                f"Consider: (1) review backbase_impact values — may be too conservative, "
+                f"(2) check if implementation/effectiveness curves are too slow, "
+                f"(3) run roi_calibrator.py --config roi_config.json for expansion proposals, "
+                f"(4) verify investment isn't over-estimated."
+            )
+        elif curve_roi > high:
+            warnings.append(
+                f"    ⚠ ROI {curve_roi:.0f}% is ABOVE {segment} benchmark range ({low}-{high}%). "
+                f"A consultant presenting {curve_roi:.0f}% ROI will lose credibility. "
+                f"Review: (1) attribution — are top levers genuinely Backbase-driven or bank strategic decisions? "
+                f"(2) baselines — is the full customer base addressable or only digitally active subset? "
+                f"(3) backbase_impact — any P3 assumptions above 0.40 should be reduced, "
+                f"(4) investment — is it adequate for a bank this size? "
+                f"(5) interdependency — apply 10-20% haircut if multiple levers share the same customer base."
+            )
+
+    if warnings:
+        log("  ⚠ ROI VALIDATION WARNINGS:", C.YELLOW)
+        for w in warnings:
+            log(w, C.YELLOW)
+
+    if modified:
+        config_path.write_text(json.dumps(config, indent=2, ensure_ascii=False))
+        log(f"  ✓ roi_config.json updated — impacts capped at {MAX_BACKBASE_IMPACT:.0%}", C.GREEN)
+    elif not warnings:
+        log("  ✓ roi_config.json passed reasonableness checks", C.GREEN)
+
+    report["warnings"] = warnings
+    report["modified"] = modified
+    report["passed"] = not warnings
+    return report
+
+
+# ─── De-anonymization Gate (moved from orchestrate.py run_pipeline step 6b) ──
+
+def deanonymize_dir(outputs_dir, mapping_file=None) -> dict:
+    """Restore client names in final outputs using .pii_mapping.json.
+
+    Moved from orchestrate.py run_pipeline step 6b. A missing mapping is
+    reported LOUDLY as "NOT client-ready" — never silently skipped — and no
+    file is modified in that case.
+
+    mapping_file defaults to <outputs_dir parent>/.pii_mapping.json (the
+    pipeline layout, where outputs_dir = engagement_dir/outputs), falling
+    back to <outputs_dir>/.pii_mapping.json for standalone callers.
+    """
+    outputs_dir = Path(outputs_dir)
+    if mapping_file is None:
+        candidate = outputs_dir.parent / ".pii_mapping.json"
+        if not candidate.exists():
+            local = outputs_dir / ".pii_mapping.json"
+            candidate = local if local.exists() else candidate
+        mapping_file = candidate
+    mapping_file = Path(mapping_file)
+
+    report = {
+        "gate": "deanonymize_dir",
+        "outputs_dir": str(outputs_dir),
+        "mapping_file": str(mapping_file),
+        "client_ready": False,
+        "files_restored": 0,
+        "error": None,
+    }
+
+    if not mapping_file.exists():
+        log(f"  ✗ NO PII MAPPING FOUND ({mapping_file.name}) — outputs are NOT client-ready.", C.RED)
+        log("    Outputs may still contain anonymization placeholders. "
+            "Run the pipeline's anonymization step or supply the mapping file "
+            "before sharing anything with the client.", C.RED)
+        report["error"] = "missing_pii_mapping"
+        return report
+
+    log("  Restoring client names in final outputs...", C.CYAN)
+    try:
+        from anonymize_transcript import deanonymize_text
+    except ImportError:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from anonymize_transcript import deanonymize_text
+
+    try:
+        pii_mapping = json.loads(mapping_file.read_text())
+        if pii_mapping:
+            deanon_count = 0
+            for out_file in outputs_dir.iterdir():
+                if out_file.suffix in ('.md', '.html', '.json', '.txt') and not out_file.name.startswith('interim'):
+                    content = out_file.read_text()
+                    restored = deanonymize_text(content, pii_mapping)
+                    if restored != content:
+                        out_file.write_text(restored)
+                        deanon_count += 1
+            log(f"  ✓ De-anonymized {deanon_count} output file(s)")
+            report["files_restored"] = deanon_count
+        report["client_ready"] = True
+    except Exception as e:
+        log(f"  ⚠ De-anonymization failed: {type(e).__name__} — outputs may contain placeholders", C.YELLOW)
+        report["error"] = type(e).__name__
+    return report
+
+
+# ─── Output Validation Gate (moved from orchestrate.py step_validate) ────────
+
+def validate_outputs(engagement_dir, engagement_type: str = "assessment") -> dict:
+    """Run the validation gate script (thin wrapper over validate_engagement_outputs.sh)."""
+    engagement_dir = Path(engagement_dir)
+    script = REPO_ROOT / "scripts" / "validate_engagement_outputs.sh"
+    report = {
+        "gate": "validate_outputs",
+        "engagement_dir": str(engagement_dir),
+        "engagement_type": engagement_type,
+        "passed": False,
+        "skipped": False,
+    }
+    if not script.exists():
+        log("  ⚠ validate_engagement_outputs.sh not found — skipping", C.YELLOW)
+        report["passed"] = True
+        report["skipped"] = True
+        return report
+
+    result = subprocess.run(
+        ["bash", str(script), str(engagement_dir), engagement_type],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        log("  ✓ Validation gate PASSED", C.GREEN)
+        report["passed"] = True
+    else:
+        log(f"  ✗ Validation gate FAILED:\n{result.stdout}\n{result.stderr}", C.RED)
+    return report
+
+
+# ─── Minimal CLI for skill callers ────────────────────────────────────────────
+
+def _usage() -> str:
+    return (
+        "Usage:\n"
+        "  python3 scripts/artifact_boundary.py cap <roi_config.json>\n"
+        "  python3 scripts/artifact_boundary.py deanon <engagement_or_outputs_dir>\n"
+        "  python3 scripts/artifact_boundary.py validate <engagement_dir> [engagement_type]\n"
+    )
+
+
+def main(argv) -> int:
+    if len(argv) < 2:
+        print(_usage(), file=sys.stderr)
+        return 2
+
+    cmd = argv[0]
+    if cmd == "cap":
+        report = cap_roi_config(argv[1])
+        print(json.dumps(report, indent=2))
+        if not report["exists"] or report["parse_error"]:
+            return 1
+        return 0
+    elif cmd == "deanon":
+        target = Path(argv[1])
+        # Accept either an engagement dir (containing outputs/) or an outputs dir
+        outputs_dir = target / "outputs" if (target / "outputs").is_dir() else target
+        report = deanonymize_dir(outputs_dir)
+        print(json.dumps(report, indent=2))
+        return 0 if report["client_ready"] else 1
+    elif cmd == "validate":
+        engagement_type = argv[2] if len(argv) > 2 else "assessment"
+        report = validate_outputs(argv[1], engagement_type)
+        print(json.dumps(report, indent=2))
+        return 0 if report["passed"] else 1
+    else:
+        print(_usage(), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -37,7 +37,8 @@ sys.stdout.reconfigure(line_buffering=True)
 sys.stderr.reconfigure(line_buffering=True)
 from pathlib import Path
 
-from anonymize_transcript import anonymize_transcript_file, deanonymize_text
+from anonymize_transcript import anonymize_transcript_file
+from artifact_boundary import cap_roi_config, deanonymize_dir, validate_outputs
 from typing import Optional
 
 from claude_agent_sdk import (
@@ -321,180 +322,9 @@ def _sum_costs(results) -> float:
     return total
 
 
-MAX_BACKBASE_IMPACT = 0.60
-
-# Segment benchmark ranges for ROI validation (from roi_calibrator.py)
-SEGMENT_ROI_RANGES = {
-    "Retail Banking": (100, 150),
-    "Wealth Management": (120, 200),
-    "Commercial Banking": (80, 140),
-    "SME Banking": (70, 130),
-    "Corporate Banking": (100, 150),
-    "Investing": (100, 150),
-}
-
-
-def _compute_5yr_roi(config: dict) -> float | None:
-    """Compute 5-year ROI from config using curves (matching Excel logic)."""
-    groups = config.get('value_lever_groups', config.get('journeys', {}))
-    bl = config.get('backbase_loading', {})
-    impl_curve = bl.get('implementation_curve', [0.3, 0.7, 0.8, 1.0, 1.0])
-    eff_curve = bl.get('effectiveness_curve', [0.15, 0.35, 0.6, 0.85, 1.0])
-
-    # Sum steady-state annual benefit across all drivers
-    total_steady_state = 0
-    for group in groups.values():
-        for dtype in ('revenue_drivers', 'cost_drivers'):
-            for driver in group.get(dtype, {}).values():
-                baseline = driver.get('baseline_annual', 0)
-                bi = driver.get('inputs', {}).get('backbase_impact', {})
-                impact = bi.get('value', 0) if isinstance(bi, dict) else bi if isinstance(bi, (int, float)) else 0
-                total_steady_state += baseline * impact
-        # Add servicing analysis totals
-        sa = group.get('servicing_analysis')
-        if isinstance(sa, dict):
-            for channel in sa.values():
-                if isinstance(channel, dict):
-                    for task in channel.get('tasks', []):
-                        if isinstance(task, dict):
-                            total_steady_state += task.get('total_saved', 0)
-
-    # Apply curves year by year (matching Excel logic)
-    total_5yr_benefit = 0
-    for yr in range(5):
-        impl = impl_curve[yr] if yr < len(impl_curve) else 1.0
-        eff = eff_curve[yr] if yr < len(eff_curve) else 1.0
-        total_5yr_benefit += total_steady_state * impl * eff
-
-    # Sum investment
-    inv = config.get('investment', {})
-    total_investment = 0
-    for inv_type in ('license', 'implementation'):
-        inv_data = inv.get(inv_type, {})
-        if isinstance(inv_data, dict):
-            for yr_key in ('year_1', 'year_2', 'year_3', 'year_4', 'year_5'):
-                total_investment += inv_data.get(yr_key, 0)
-        elif isinstance(inv_data, (int, float)):
-            total_investment += inv_data
-
-    if total_investment <= 0:
-        return None
-
-    return (total_5yr_benefit - total_investment) / total_investment * 100
-
-
-def _validate_roi_config(config_path: Path):
-    """Validate roi_config.json for unreasonable values. Caps impacts and warns."""
-    if not config_path.exists():
-        return
-    try:
-        config = json.loads(config_path.read_text())
-    except Exception as e:
-        log(f"  ⚠ Could not parse roi_config.json: {type(e).__name__}", C.YELLOW)
-        return
-
-    warnings = []
-    modified = False
-    total_benefit = 0
-    client_revenue = config.get('bank_profile', {}).get('total_revenue', 0)
-
-    groups = config.get('value_lever_groups', config.get('journeys', {}))
-    for group_key, group in groups.items():
-        for driver_type in ('revenue_drivers', 'cost_drivers'):
-            for drv_key, driver in group.get(driver_type, {}).items():
-                bi = driver.get('inputs', {}).get('backbase_impact', {})
-                val = bi.get('value', 0) if isinstance(bi, dict) else bi if isinstance(bi, (int, float)) else 0
-                if isinstance(val, (int, float)) and val > MAX_BACKBASE_IMPACT:
-                    warnings.append(
-                        f"    {drv_key}: backbase_impact {val:.0%} → capped to {MAX_BACKBASE_IMPACT:.0%}"
-                    )
-                    if isinstance(bi, dict):
-                        bi['value'] = MAX_BACKBASE_IMPACT
-                    modified = True
-                baseline = driver.get('baseline_annual', 0)
-                impact = bi.get('value', 0.30) if isinstance(bi, dict) else bi if isinstance(bi, (int, float)) else 0.30
-                total_benefit += baseline * impact
-
-    # Cap scenario-level impacts
-    for sc_name, sc in config.get('scenarios', {}).items():
-        if not isinstance(sc, dict):
-            continue
-        for imp_key, imp_val in sc.get('backbase_impacts', {}).items():
-            if isinstance(imp_val, (int, float)) and imp_val > MAX_BACKBASE_IMPACT:
-                warnings.append(
-                    f"    Scenario '{sc_name}' impact '{imp_key}': {imp_val:.0%} → capped to {MAX_BACKBASE_IMPACT:.0%}"
-                )
-                sc['backbase_impacts'][imp_key] = MAX_BACKBASE_IMPACT
-                modified = True
-
-    # --- OVERESTIMATION CHECKS ---
-    investment = config.get('total_investment', 0)
-    if investment > 0 and total_benefit > 0:
-        five_yr_roi_simple = (total_benefit * 5 - investment) / investment * 100
-        if five_yr_roi_simple > 500:
-            warnings.append(
-                f"    5-year ROI (simple) = {five_yr_roi_simple:.0f}% — exceeds 500% threshold, review baselines"
-            )
-
-    if client_revenue > 0 and total_benefit > client_revenue * 0.05:
-        warnings.append(
-            f"    Total annual benefit ${total_benefit:,.0f} exceeds 5% of client revenue ${client_revenue:,.0f}"
-        )
-
-    # --- UNDERESTIMATION CHECK (NEW) ---
-    # Compute curve-adjusted ROI (matches Excel logic)
-    curve_roi = _compute_5yr_roi(config)
-    if curve_roi is not None:
-        # Detect segment
-        industry = config.get('industry', '').lower()
-        segment = "Retail Banking"  # default
-        for seg_name in SEGMENT_ROI_RANGES:
-            if seg_name.lower().replace(' ', '') in industry.replace(' ', '').lower():
-                segment = seg_name
-                break
-        if 'wealth' in industry:
-            segment = "Wealth Management"
-        elif 'invest' in industry:
-            segment = "Investing"
-        elif 'commercial' in industry:
-            segment = "Commercial Banking"
-        elif 'sme' in industry or 'small' in industry:
-            segment = "SME Banking"
-        elif 'corporate' in industry:
-            segment = "Corporate Banking"
-
-        low, high = SEGMENT_ROI_RANGES.get(segment, (60, 150))
-        log(f"  📊 Curve-adjusted 5-year ROI: {curve_roi:.0f}% (segment: {segment}, benchmark: {low}-{high}%)", C.CYAN)
-
-        if curve_roi < low:
-            warnings.append(
-                f"    ⚠ ROI {curve_roi:.0f}% is BELOW {segment} benchmark range ({low}-{high}%). "
-                f"Consider: (1) review backbase_impact values — may be too conservative, "
-                f"(2) check if implementation/effectiveness curves are too slow, "
-                f"(3) run roi_calibrator.py --config roi_config.json for expansion proposals, "
-                f"(4) verify investment isn't over-estimated."
-            )
-        elif curve_roi > high:
-            warnings.append(
-                f"    ⚠ ROI {curve_roi:.0f}% is ABOVE {segment} benchmark range ({low}-{high}%). "
-                f"A consultant presenting {curve_roi:.0f}% ROI will lose credibility. "
-                f"Review: (1) attribution — are top levers genuinely Backbase-driven or bank strategic decisions? "
-                f"(2) baselines — is the full customer base addressable or only digitally active subset? "
-                f"(3) backbase_impact — any P3 assumptions above 0.40 should be reduced, "
-                f"(4) investment — is it adequate for a bank this size? "
-                f"(5) interdependency — apply 10-20% haircut if multiple levers share the same customer base."
-            )
-
-    if warnings:
-        log("  ⚠ ROI VALIDATION WARNINGS:", C.YELLOW)
-        for w in warnings:
-            log(w, C.YELLOW)
-
-    if modified:
-        config_path.write_text(json.dumps(config, indent=2, ensure_ascii=False))
-        log(f"  ✓ roi_config.json updated — impacts capped at {MAX_BACKBASE_IMPACT:.0%}", C.GREEN)
-    elif not warnings:
-        log("  ✓ roi_config.json passed reasonableness checks", C.GREEN)
+# ROI capping/validation logic (MAX_BACKBASE_IMPACT, SEGMENT_ROI_RANGES,
+# _compute_5yr_roi, _validate_roi_config) moved to artifact_boundary.py so the
+# same gates run in both the pipeline and standalone skill paths.
 
 
 # ─── Resilient Query Wrapper ──────────────────────────────────────────────────
@@ -1372,7 +1202,7 @@ REQUIRED OUTPUT FILES:
     assert_file_exists(outputs_dir / "roi_config.json", "ROI")
 
     # ── ROI Reasonableness Gate ───────────────────────────────────────────
-    _validate_roi_config(outputs_dir / "roi_config.json")
+    cap_roi_config(outputs_dir / "roi_config.json")
 
     for f, name in [
         ("journey_maps.json", "Journey Builder"),
@@ -2224,22 +2054,8 @@ Write the output to: {outputs_dir}/
 
 
 async def step_validate(engagement_dir: Path, outputs_dir: Path) -> bool:
-    """Run the validation gate script."""
-    script = REPO_ROOT / "scripts" / "validate_engagement_outputs.sh"
-    if not script.exists():
-        log("  ⚠ validate_engagement_outputs.sh not found — skipping", C.YELLOW)
-        return True
-
-    result = subprocess.run(
-        ["bash", str(script), str(engagement_dir), "assessment"],
-        capture_output=True, text=True,
-    )
-    if result.returncode == 0:
-        log("  ✓ Validation gate PASSED", C.GREEN)
-        return True
-    else:
-        log(f"  ✗ Validation gate FAILED:\n{result.stdout}\n{result.stderr}", C.RED)
-        return False
+    """Run the validation gate script (moved to artifact_boundary.validate_outputs)."""
+    return validate_outputs(engagement_dir, "assessment")["passed"]
 
 
 # ─── T4: Pipeline Summary ────────────────────────────────────────────────────
@@ -2424,23 +2240,9 @@ async def run_pipeline(
             log("  Pipeline completed with validation warnings.", C.YELLOW)
 
     # ── Step 6b: De-anonymize final outputs ─────────────────────────────
-    pii_mapping_file = engagement_dir / ".pii_mapping.json"
-    if pii_mapping_file.exists():
-        log("  Restoring client names in final outputs...", C.CYAN)
-        try:
-            pii_mapping = json.loads(pii_mapping_file.read_text())
-            if pii_mapping:
-                deanon_count = 0
-                for out_file in outputs_dir.iterdir():
-                    if out_file.suffix in ('.md', '.html', '.json', '.txt') and not out_file.name.startswith('interim'):
-                        content = out_file.read_text()
-                        restored = deanonymize_text(content, pii_mapping)
-                        if restored != content:
-                            out_file.write_text(restored)
-                            deanon_count += 1
-                log(f"  ✓ De-anonymized {deanon_count} output file(s)")
-        except Exception as e:
-            log(f"  ⚠ De-anonymization failed: {type(e).__name__} — outputs may contain placeholders", C.YELLOW)
+    # Moved to artifact_boundary.deanonymize_dir — a missing .pii_mapping.json
+    # is reported loudly as NOT client-ready, never silently skipped.
+    deanonymize_dir(outputs_dir, engagement_dir / ".pii_mapping.json")
 
     # Clean up anonymized transcript copies (keep mapping for audit trail)
     for anon_file in (engagement_dir / "inputs").glob(".anon_transcript_*"):

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -100,11 +100,8 @@ def glob_files(pattern: str, directory: Path) -> list[Path]:
     return sorted(directory.glob(pattern))
 
 
-def parse_agent_md(agent_name: str) -> tuple[str, str]:
-    """Read agent .md file, return (system_prompt_body, model)."""
-    path = AGENTS_DIR / f"{agent_name}.md"
-    text = read_file(path)
-    # Strip YAML frontmatter
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Strip YAML frontmatter from agent markdown. Returns (body, model)."""
     if text.startswith("---"):
         parts = text.split("---", 2)
         if len(parts) >= 3:
@@ -115,6 +112,194 @@ def parse_agent_md(agent_name: str) -> tuple[str, str]:
             model = model_match.group(1) if model_match else "sonnet"
             return body, model
     return text, "sonnet"
+
+
+def parse_agent_md(agent_name: str) -> tuple[str, str]:
+    """Read agent .md file, return (system_prompt_body, model)."""
+    path = AGENTS_DIR / f"{agent_name}.md"
+    return _split_frontmatter(read_file(path))
+
+
+# ─── Mode Composer (skill-first contracts — .design/solution-design-v3.md) ────
+#
+# Extracted agents carry their operating contracts as `### Mode: <name>` blocks
+# inside a `## Modes` section of their own .md file. The composer builds the
+# invocation prompt from core identity + ONE selected mode + runtime params.
+# Legacy agents (no `## Modes` section) keep using inline prompts via
+# run_agent(agent_name, prompt=...) — mixed state is supported throughout.
+
+_MODES_HEADING = re.compile(r"(?m)^##\s+Modes\s*$")
+_NEXT_H2 = re.compile(r"(?m)^##[ \t]+(?!Modes\s*$)\S")
+_MODE_SPLIT = re.compile(r"(?m)^###\s+Mode:\s*")
+_MODE_NAME = re.compile(r"^([A-Za-z0-9_-]+)")
+_YAML_FENCE = re.compile(r"```yaml\s*\n(.*?)\n```", re.DOTALL)
+_PLACEHOLDER = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+# Complete key set per the design — no speculative fields.
+_MODE_CONTRACT_KEYS = {
+    "inputs", "degraded", "knowledge", "outputs",
+    "checkpoint", "phases", "gates", "params",
+}
+_INPUTS_KEYS = {"required", "optional"}
+
+
+def _import_yaml():
+    try:
+        import yaml
+        return yaml
+    except ImportError as e:
+        raise RuntimeError(
+            "parse_agent_modes requires PyYAML (`pip install pyyaml`) — "
+            "only needed for mode-extracted agents; legacy inline prompts are unaffected."
+        ) from e
+
+
+def parse_agent_modes(path) -> dict:
+    """Parse the `## Modes` section of an agent .md file.
+
+    Returns {mode_name: {"contract": dict, "prose": str, "raw": str}} where
+    `contract` is the parsed fenced-YAML block, `prose` is the remaining
+    behavior text, and `raw` is the full mode block (heading + yaml + prose)
+    as written. A file without a `## Modes` section returns {} (legacy agent).
+    """
+    path = Path(path)
+    body, _ = _split_frontmatter(read_file(path))
+
+    heading = _MODES_HEADING.search(body)
+    if not heading:
+        return {}
+    section = body[heading.end():]
+    # The Modes section ends at the next level-2 heading, if any.
+    nxt = _NEXT_H2.search(section)
+    if nxt:
+        section = section[:nxt.start()]
+
+    yaml = _import_yaml()
+    modes: dict = {}
+    blocks = _MODE_SPLIT.split(section)[1:]  # drop preamble before first mode
+    for block in blocks:
+        name_match = _MODE_NAME.match(block.strip())
+        if not name_match:
+            raise ValueError(f"{path.name}: malformed '### Mode:' heading in ## Modes section")
+        name = name_match.group(1)
+        if name in modes:
+            raise ValueError(f"{path.name}: duplicate mode '{name}' in ## Modes section")
+
+        fence = _YAML_FENCE.search(block)
+        contract = {}
+        if fence:
+            contract = yaml.safe_load(fence.group(1)) or {}
+        if not isinstance(contract, dict):
+            raise ValueError(f"{path.name}: mode '{name}' YAML contract must be a mapping")
+
+        unknown = set(contract) - _MODE_CONTRACT_KEYS
+        if unknown:
+            raise ValueError(
+                f"{path.name}: mode '{name}' has unknown contract key(s): {sorted(unknown)} "
+                f"(allowed: {sorted(_MODE_CONTRACT_KEYS)})"
+            )
+        inputs = contract.get("inputs", {})
+        if inputs and (not isinstance(inputs, dict) or set(inputs) - _INPUTS_KEYS):
+            raise ValueError(
+                f"{path.name}: mode '{name}' inputs must be a mapping with keys "
+                f"{sorted(_INPUTS_KEYS)} only"
+            )
+
+        prose = _YAML_FENCE.sub("", block)
+        # Drop the name line (incl. trailing comments) — keep behavior prose only.
+        prose = "\n".join(prose.strip().split("\n")[1:]).strip()
+        modes[name] = {
+            "contract": contract,
+            "prose": prose,
+            "raw": f"### Mode: {name}\n" + "\n".join(block.strip().split("\n")[1:]).strip(),
+        }
+    return modes
+
+
+def _substitute_params(text: str, params: dict, context: str) -> str:
+    """Substitute {placeholder} tokens with param VALUES. Unknown placeholders raise."""
+    def repl(m):
+        key = m.group(1)
+        if key not in params:
+            raise KeyError(
+                f"Unknown placeholder '{{{key}}}' in {context} — not provided in params "
+                f"(available: {sorted(params)})"
+            )
+        return str(params[key])
+    return _PLACEHOLDER.sub(repl, text)
+
+
+def _preflight_required_inputs(contract: dict, params: dict, agent_name: str, mode: str):
+    """Check the mode's required input files exist before spending an agent run.
+
+    degraded: refuse  -> missing required input is a hard error (pipeline behavior)
+    otherwise         -> warn and proceed (the agent handles degradation per its prose)
+    """
+    required = (contract.get("inputs") or {}).get("required") or []
+    missing = []
+    for entry in required:
+        resolved = _substitute_params(str(entry), params, f"{agent_name}/{mode} inputs.required")
+        p = Path(resolved)
+        if not p.is_absolute():
+            p = REPO_ROOT / p
+        if not p.exists():
+            missing.append(str(p))
+    if not missing:
+        return
+    degraded = contract.get("degraded", "refuse")
+    if degraded == "refuse":
+        raise RuntimeError(
+            f"REQUIRED INPUT MISSING: agent '{agent_name}' mode '{mode}' (degraded: refuse) "
+            f"cannot run — missing: {missing}"
+        )
+    log(f"  ⚠ {agent_name}/{mode}: missing optional-degradable required input(s): {missing} "
+        f"(degraded: {degraded} — proceeding)", C.YELLOW)
+
+
+def compose_prompt(agent_name: str, mode: str, params: Optional[dict] = None) -> str:
+    """Compose an invocation prompt: core identity + ONE mode block + params table.
+
+    `agent_name` is an agent in .claude/agents/, or a direct path to a .md file
+    (used by fixtures/tests). Core identity is everything above `## Modes`
+    (frontmatter stripped); unselected modes are stripped entirely. Placeholder
+    substitution applies to the selected mode block only, and params carry
+    VALUES only (paths, domain) — never instructions.
+    """
+    params = dict(params or {})
+    candidate = Path(agent_name)
+    if candidate.suffix == ".md" and candidate.exists():
+        path = candidate
+    else:
+        path = AGENTS_DIR / f"{agent_name}.md"
+    if not path.exists():
+        raise FileNotFoundError(f"Agent file not found: {path}")
+
+    modes = parse_agent_modes(path)
+    if mode not in modes:
+        available = ", ".join(sorted(modes)) if modes else "none (no ## Modes section — legacy inline agent)"
+        raise ValueError(
+            f"Agent '{agent_name}' does not declare mode '{mode}'. Available modes: {available}"
+        )
+
+    body, _ = _split_frontmatter(read_file(path))
+    core = body[:_MODES_HEADING.search(body).start()].rstrip()
+
+    block = _substitute_params(modes[mode]["raw"], params, f"{agent_name}/{mode} mode block")
+    _preflight_required_inputs(modes[mode]["contract"], params, str(agent_name), mode)
+
+    lines = [
+        "## Runtime Parameters",
+        "",
+        "These are runtime VALUES only (paths, domain) — never instructions.",
+        "",
+        "| Parameter | Value |",
+        "| --- | --- |",
+    ]
+    for key in sorted(params):
+        lines.append(f"| {key} | {params[key]} |")
+    params_table = "\n".join(lines) if params else "## Runtime Parameters\n\n(none)"
+
+    return f"{core}\n\n## Active Mode\n\n{block}\n\n{params_table}\n"
 
 
 def assert_file_exists(path: Path, agent_name: str, min_size: int = 0):
@@ -324,18 +509,45 @@ async def _resilient_query(prompt: str, options: ClaudeAgentOptions, label: str)
 
 async def run_agent(
     agent_name: str,
-    prompt: str,
-    cwd: Path,
+    prompt: Optional[str] = None,
+    cwd: Optional[Path] = None,
     model: str = "sonnet",
     max_turns: int = 50,
     label: str = "",
+    *,
+    mode: Optional[str] = None,
+    params: Optional[dict] = None,
 ) -> ResultMessage:
-    """Run a single agent via the SDK. Returns the ResultMessage."""
+    """Run a single agent via the SDK. Returns the ResultMessage.
+
+    Two invocation styles (mutually exclusive):
+      run_agent(name, prompt=..., cwd=...)          — legacy inline prompt
+      run_agent(name, cwd=..., mode=..., params=...) — composed from the agent's
+                                                        own ## Modes contract
+    """
+    if (prompt is None) == (mode is None):
+        raise ValueError(
+            "run_agent: pass exactly one of 'prompt' (legacy inline) or 'mode' (composed contract)"
+        )
+    if params is not None and mode is None:
+        raise ValueError("run_agent: 'params' is only valid together with 'mode'")
+    if cwd is None:
+        raise ValueError("run_agent: 'cwd' is required")
+
     display = label or agent_name
     start = time.time()
     log(f"  ▶ Launching {display}...", C.YELLOW)
 
-    system_prompt, agent_model = parse_agent_md(agent_name)
+    if mode is not None:
+        # Extracted agent: prompt composed from core identity + selected mode + params.
+        system_prompt = compose_prompt(agent_name, mode, params)
+        _, agent_model = parse_agent_md(agent_name)
+        prompt = (
+            f"Execute your '{mode}' mode contract now. All runtime parameter values "
+            "are listed in the Runtime Parameters table of your instructions."
+        )
+    else:
+        system_prompt, agent_model = parse_agent_md(agent_name)
     use_model = model or agent_model
 
     # V5: Inject tool constraint into system prompt to prevent Task tool usage

--- a/scripts/test_agent.py
+++ b/scripts/test_agent.py
@@ -109,6 +109,171 @@ def get_agent_name(filepath: str) -> str:
     return name
 
 
+# ─── Mode structural checks (ticket #103 — skill-first contracts) ────────────
+#
+# Extracted agents carry their operating contracts as `### Mode: <name>`
+# blocks inside a `## Modes` section (see .design/solution-design-v3.md and
+# scripts/orchestrate.py's Mode Composer, ticket #101). This reuses
+# orchestrate.py's parse_agent_modes() rather than writing a second
+# YAML/mode parser here — it only validates structure, never invokes agents.
+
+_MODES_HEADING_RE = re.compile(r'(?m)^##\s+Modes\s*$')
+_MODE_PLACEHOLDER_RE = re.compile(r'\{[A-Za-z_][A-Za-z0-9_]*\}')
+_REQUIRED_MODE_KEYS = ('inputs', 'outputs', 'checkpoint')
+
+# Agents this repo has decided will never carry a `## Modes` section
+# (Ignite Inspire workshop-driven agents + the pipeline router), plus
+# anything under .claude/agents/deprecated/. Mode checks never fire for
+# these, even if a `## Modes` heading were accidentally added.
+_MODE_CHECK_EXCLUDED_AGENTS = {
+    'workshop-preparation',
+    'ignite-workshop-synthesizer',
+    'usecase-designer',
+    'upgrade-analysis',
+    'value-consulting-orchestrator',
+}
+
+_parse_agent_modes_fn = None  # lazy-imported + cached
+
+
+def _get_parse_agent_modes():
+    """Guarded import of parse_agent_modes from scripts/orchestrate.py.
+
+    orchestrate.py imports `claude_agent_sdk` at module level, which these
+    structural checks don't need (no agent is ever invoked here). Stub the
+    module before import if it's not installed, mirroring the established
+    pattern in tests/fixtures/mode_composer_selftest.py. Otherwise
+    orchestrate.py imports fine under Python 3.10+ (CI runs 3.11).
+    """
+    global _parse_agent_modes_fn
+    if _parse_agent_modes_fn is not None:
+        return _parse_agent_modes_fn
+
+    try:
+        import claude_agent_sdk  # noqa: F401
+    except ImportError:
+        import types
+        stub = types.ModuleType('claude_agent_sdk')
+        for name in ('query', 'ClaudeAgentOptions', 'AssistantMessage',
+                     'ResultMessage', 'TextBlock', 'ToolUseBlock'):
+            setattr(stub, name, type(name, (), {}))
+        sys.modules['claude_agent_sdk'] = stub
+
+    scripts_dir = str(Path(__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    try:
+        from orchestrate import parse_agent_modes
+    except Exception as e:
+        raise RuntimeError(
+            "Could not import parse_agent_modes from scripts/orchestrate.py "
+            f"({e.__class__.__name__}: {e}). The mode structural check "
+            "requires Python 3.10+ (CI runs 3.11)."
+        ) from e
+
+    _parse_agent_modes_fn = parse_agent_modes
+    return _parse_agent_modes_fn
+
+
+def check_agent_modes(filepath: str, content: str, expected_modes_map: dict) -> list:
+    """Structural checks for the `## Modes` skill-first contract.
+
+    Returns [] (no new check fires) for:
+      - files without a `## Modes` section — legacy inline agents
+      - agents in _MODE_CHECK_EXCLUDED_AGENTS or under .claude/agents/deprecated/
+
+    For files that declare modes:
+      - the `## Modes` section must parse (reuses orchestrate.py's
+        parse_agent_modes — malformed YAML or duplicate/unknown-key modes
+        fail here, naming the file and the underlying parse error)
+      - each `### Mode:` block's contract must carry inputs/outputs/checkpoint,
+        plus params if the block uses any {placeholder}
+      - if the agent has a declared expected-modes set in quality_metrics.yaml
+        (tests/quality_metrics.yaml: agent_modes), the parsed mode set must
+        match exactly — a renamed/missing mode fails, naming the agent and
+        the missing/unexpected mode(s)
+    """
+    if not _MODES_HEADING_RE.search(content):
+        return []
+
+    agent_name = get_agent_name(filepath)
+    if agent_name in _MODE_CHECK_EXCLUDED_AGENTS or '.claude/agents/deprecated/' in filepath:
+        return []
+
+    try:
+        parse_agent_modes = _get_parse_agent_modes()
+    except RuntimeError as e:
+        return [{
+            'name': f'Modes: {agent_name} — parse_agent_modes importable',
+            'passed': False,
+            'matches': 0,
+            'reason': str(e),
+        }]
+
+    try:
+        modes = parse_agent_modes(filepath)
+    except Exception as e:
+        return [{
+            'name': f'Modes: {agent_name} — "## Modes" section parses',
+            'passed': False,
+            'matches': 0,
+            'reason': f'{filepath}: {e}',
+        }]
+
+    results = [{
+        'name': f'Modes: {agent_name} — "## Modes" section parses',
+        'passed': True,
+        'matches': len(modes),
+        'reason': '',
+    }]
+
+    for mode_name, mode_data in sorted(modes.items()):
+        contract = mode_data.get('contract', {}) or {}
+        raw = mode_data.get('raw', '') or ''
+
+        required_keys = list(_REQUIRED_MODE_KEYS)
+        if _MODE_PLACEHOLDER_RE.search(raw):
+            required_keys.append('params')
+
+        for key in required_keys:
+            has_key = key in contract
+            results.append({
+                'name': f'Modes: {agent_name}/{mode_name} — has "{key}"',
+                'passed': has_key,
+                'matches': 1 if has_key else 0,
+                'reason': '' if has_key else
+                    f'{filepath}: mode "{mode_name}" missing required key "{key}"',
+            })
+
+    expected = expected_modes_map.get(agent_name)
+    if expected is not None:
+        found = set(modes)
+        expected_set = set(expected)
+        ok = found == expected_set
+        reason = ''
+        if not ok:
+            missing = sorted(expected_set - found)
+            extra = sorted(found - expected_set)
+            parts = []
+            if missing:
+                parts.append(f'missing: {missing}')
+            if extra:
+                parts.append(f'unexpected: {extra}')
+            reason = (
+                f'{filepath}: agent "{agent_name}" declares modes {sorted(found)}, '
+                f'expected {sorted(expected_set)} ({"; ".join(parts)})'
+            )
+        results.append({
+            'name': f'Modes: {agent_name} — declares expected mode set',
+            'passed': ok,
+            'matches': len(found & expected_set),
+            'reason': reason,
+        })
+
+    return results
+
+
 def run_checks(files: list, metrics: dict) -> dict:
     """Run all applicable checks against changed files."""
     all_results = {}
@@ -142,6 +307,19 @@ def run_checks(files: list, metrics: dict) -> dict:
             continue
 
         results = check_file(filepath, checks_to_run)
+
+        # Mode structural checks (ticket #103) — only meaningful for agent
+        # definition files, and only when the file actually declares a
+        # `## Modes` section (check_agent_modes no-ops otherwise).
+        if file_type == 'agent_definition':
+            try:
+                content = Path(filepath).read_text(encoding='utf-8')
+            except (FileNotFoundError, UnicodeDecodeError, ValueError):
+                content = ''
+            if content:
+                modes_map = metrics.get('agent_modes', {}) or {}
+                results = results + check_agent_modes(filepath, content, modes_map)
+
         all_results[filepath] = results
 
         for r in results:

--- a/tests/fixtures/mode_composer_selftest.py
+++ b/tests/fixtures/mode_composer_selftest.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Self-test for the mode composer in scripts/orchestrate.py (ticket #101).
+
+Run manually from the repo root:
+    python3 tests/fixtures/mode_composer_selftest.py
+
+Covers the ticket's acceptance criteria against tests/fixtures/mode_fixture_agent.md:
+  - compose_prompt(fixture, "pipeline", params) -> core + pipeline block only,
+    {placeholders} substituted
+  - missing mode -> clear error naming available modes
+  - required-input preflight (degraded: refuse) fails before an agent run
+  - unknown {placeholder} raises, never silently passes through
+  - parse_agent_modes on a file without ## Modes returns {}
+  - run_agent prompt/mode mutual exclusivity
+
+Exit code 0 = all checks pass.
+"""
+import asyncio
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+# Stub the Claude Agent SDK if absent so orchestrate.py imports in dev
+# environments — this self-test never launches an agent.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ImportError:
+    stub = types.ModuleType("claude_agent_sdk")
+    for name in ("query", "ClaudeAgentOptions", "AssistantMessage",
+                 "ResultMessage", "TextBlock", "ToolUseBlock"):
+        setattr(stub, name, type(name, (), {}))
+    sys.modules["claude_agent_sdk"] = stub
+
+import orchestrate  # noqa: E402
+
+FIXTURE = ROOT / "tests" / "fixtures" / "mode_fixture_agent.md"
+_failures = []
+
+
+def check(label: str, cond: bool, detail: str = ""):
+    status = "PASS" if cond else "FAIL"
+    print(f"  [{status}] {label}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        _failures.append(label)
+
+
+def main():
+    print(f"Fixture: {FIXTURE}")
+
+    # ── parse_agent_modes ────────────────────────────────────────────────
+    modes = orchestrate.parse_agent_modes(FIXTURE)
+    check("two modes parsed", set(modes) == {"standalone", "pipeline"}, f"got {set(modes)}")
+    pl = modes.get("pipeline", {})
+    check("pipeline contract parsed",
+          pl.get("contract", {}).get("degraded") == "refuse"
+          and pl.get("contract", {}).get("params") == ["outputs_dir", "domain"]
+          and pl.get("contract", {}).get("inputs", {}).get("required")
+          == ["{outputs_dir}/evidence_register.md"],
+          f"got {pl.get('contract')}")
+    check("pipeline prose captured", "FIXTURE-PIPELINE-PROSE" in pl.get("prose", ""))
+    check("standalone degraded=ask-inline",
+          modes.get("standalone", {}).get("contract", {}).get("degraded") == "ask-inline")
+
+    # No ## Modes section -> {} (legacy agent, e.g. any current .claude/agents file)
+    legacy = ROOT / ".claude" / "agents" / "benchmark-librarian.md"
+    if legacy.exists():
+        check("legacy agent (no ## Modes) -> {}", orchestrate.parse_agent_modes(legacy) == {})
+
+    with tempfile.TemporaryDirectory() as td:
+        outputs_dir = Path(td) / "outputs"
+        outputs_dir.mkdir()
+        (outputs_dir / "evidence_register.md").write_text("E01 fixture evidence\n")
+        params = {"outputs_dir": str(outputs_dir), "domain": "retail"}
+
+        # ── compose_prompt happy path ────────────────────────────────────
+        prompt = orchestrate.compose_prompt(str(FIXTURE), "pipeline", params)
+        check("core identity present", "FIXTURE-CORE-IDENTITY" in prompt)
+        check("selected mode block present", "FIXTURE-PIPELINE-PROSE" in prompt)
+        check("other modes stripped", "FIXTURE-STANDALONE-PROSE" not in prompt)
+        check("frontmatter stripped", "color: gray" not in prompt)
+        check("placeholders substituted",
+              str(outputs_dir) in prompt and "{outputs_dir}" not in prompt
+              and "{domain}" not in prompt)
+        check("params table present",
+              "## Runtime Parameters" in prompt and "| domain | retail |" in prompt)
+
+        # ── missing mode -> error naming available modes ─────────────────
+        try:
+            orchestrate.compose_prompt(str(FIXTURE), "excel-source", params)
+            check("missing mode raises", False)
+        except ValueError as e:
+            check("missing mode raises, names available modes",
+                  "excel-source" in str(e) and "pipeline" in str(e) and "standalone" in str(e),
+                  str(e))
+
+        # ── required-input preflight (degraded: refuse) ──────────────────
+        (outputs_dir / "evidence_register.md").unlink()
+        try:
+            orchestrate.compose_prompt(str(FIXTURE), "pipeline", params)
+            check("preflight refuses on missing required input", False)
+        except RuntimeError as e:
+            check("preflight refuses on missing required input",
+                  "REQUIRED INPUT MISSING" in str(e) and "evidence_register.md" in str(e), str(e))
+
+        # ── unknown placeholder raises ────────────────────────────────────
+        try:
+            orchestrate.compose_prompt(str(FIXTURE), "pipeline", {"outputs_dir": str(outputs_dir)})
+            check("unknown placeholder raises", False)
+        except KeyError as e:
+            check("unknown placeholder raises", "domain" in str(e), str(e))
+
+    # ── run_agent signature guards (no SDK call is reached) ──────────────
+    for label, kwargs in [
+        ("run_agent rejects prompt+mode", dict(prompt="x", mode="pipeline", cwd=ROOT)),
+        ("run_agent rejects neither prompt nor mode", dict(cwd=ROOT)),
+        ("run_agent rejects params without mode", dict(prompt="x", params={"a": 1}, cwd=ROOT)),
+    ]:
+        try:
+            asyncio.run(orchestrate.run_agent("benchmark-librarian", **kwargs))
+            check(label, False)
+        except ValueError:
+            check(label, True)
+
+    print()
+    if _failures:
+        print(f"SELF-TEST FAILED — {len(_failures)} failing check(s): {_failures}")
+        return 1
+    print("SELF-TEST PASSED — all checks green.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/mode_fixture_agent.md
+++ b/tests/fixtures/mode_fixture_agent.md
@@ -1,0 +1,51 @@
+---
+name: mode-fixture-agent
+description: Fixture agent for the orchestrate.py mode-composer self-test. NOT a real agent — never invoke in an engagement.
+model: sonnet
+color: gray
+---
+
+You are a fixture agent used only to exercise `parse_agent_modes()` and
+`compose_prompt()` in `scripts/orchestrate.py`.
+
+## Core Identity
+
+Core identity marker: FIXTURE-CORE-IDENTITY.
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes().
+     An invocation receives ONLY: core identity (everything above ## Modes)
+     + its selected mode block. Other modes are stripped. -->
+
+### Mode: standalone   <!-- default when no phase directive present -->
+```yaml
+inputs:
+  required: []
+  optional:
+    - outputs/evidence_register.md
+degraded: ask-inline
+knowledge:
+  - knowledge/domains/{domain}/benchmarks.md
+outputs:
+  - outputs/fixture_output.md
+checkpoint: interactive
+gates: []
+```
+Standalone prose marker: FIXTURE-STANDALONE-PROSE.
+
+### Mode: pipeline
+```yaml
+params: [outputs_dir, domain]
+inputs:
+  required:
+    - "{outputs_dir}/evidence_register.md"
+degraded: refuse
+knowledge:
+  - knowledge/domains/{domain}/benchmarks.md
+outputs:
+  - "{outputs_dir}/fixture_output.md"
+checkpoint: file
+phases: single
+gates: []
+```
+Pipeline prose marker: FIXTURE-PIPELINE-PROSE for domain {domain}.

--- a/tests/quality_metrics.yaml
+++ b/tests/quality_metrics.yaml
@@ -176,6 +176,26 @@ consulting_agent_definitions:
       pattern: "Consultant Checkpoint.*MANDATORY|Consultant Checkpoint"
       min_matches: 1
 
+# Skill-first mode contracts (ticket #103, .design/solution-design-v3.md).
+# Expected `## Modes` set per pipeline agent, enforced ONLY once that agent
+# has actually been extracted — i.e., its .md file contains a `## Modes`
+# section (scripts/test_agent.py::check_agent_modes no-ops otherwise, so
+# unextracted agents never fail CI on this). A renamed/missing declared mode
+# fails the check, naming the agent and the missing/unexpected mode(s).
+# Inspire-only agents and .claude/agents/deprecated/ are excluded — they are
+# not expected to ever carry a `## Modes` section.
+agent_modes:
+  discovery-transcript-interpreter: [standalone, pipeline]
+  journey-builder: [standalone, pipeline]
+  market-context-researcher: [standalone, pipeline]
+  capability-assessment: [standalone, pipeline]
+  roi-hypothesis-builder: [standalone, pipeline]
+  benchmark-librarian: [standalone, pipeline]
+  roi-financial-modeler: [standalone, pipeline, excel-source]
+  roadmap-prioritization: [standalone, pipeline]
+  narrative-assembler: [standalone, pipeline-shard, pipeline-report, html-partial]
+  knowledge-harvester: [pipeline, backfill]
+
 # Knowledge file checks
 knowledge_files:
   structural:


### PR DESCRIPTION
## Summary
PR 1 of the Skill-First Phase 1 cycle (Epic #98, plan of record: `.prd/prd-v3.md` + `.design/solution-design-v3.md`). Lands the contract infrastructure every agent extraction depends on: the mode composer in `orchestrate.py` (dormant — no step switched over), the shared artifact-boundary gates module (ROI capping / de-anonymization / validation moved out of pipeline-private code), and CI structural checks for `## Modes` sections.

## Tickets
- Closes #101 — A1: Mode composer in orchestrate.py (parse_agent_modes + compose_prompt)
- Closes #102 — A2: scripts/artifact_boundary.py — move ROI capping, de-anonymization, validation
- Closes #103 — A3: Structural mode checks in test_agent.py + quality_metrics.yaml

Also carries the cycle's planning docs (`.prd/prd-v3.md`, `.design/*-v3.md`) and the build-order provenance.

## Approach
- **Mixed-state by design (Decision 3, solution-design-v3):** `run_agent()` gains keyword-only `mode=`/`params=`, mutually exclusive with the legacy `prompt=` path; all 28 existing call sites are untouched and the composer is invoked by nothing yet. Extractions (#105–#114) switch agents over one at a time.
- **Move-not-rewrite (#102):** `cap_roi_config` was proven byte-identical to the old `_validate_roi_config` by diffing outputs across synthetic configs exercising every branch, including one extracted from the pre-move git blob.
- **One parser:** `test_agent.py` reuses `orchestrate.parse_agent_modes` via a guarded import (CI is Python 3.11); mode-set expectations live in `tests/quality_metrics.yaml` and fire only when a file actually declares `## Modes`, so nothing fails before extractions land.

## Focus Areas
- Integration: the three former call sites in `orchestrate.py` that now route through `artifact_boundary` (Block-A ROI gate, `step_validate`, step-6b de-anonymization) — confirm no call site dropped.
- Edge cases: `compose_prompt` placeholder substitution is scoped to the selected mode block; unknown placeholders raise. Preflight only hard-fails under `degraded: refuse`.
- Behavior change (intentional, per #102): an engagement with no `.pii_mapping.json` now gets a loud "NOT client-ready" report at step 6b instead of silence.

## Risk Flags
- [ ] Breaking changes: no — composer dormant; legacy path byte-identical regions verified in spec review
- [ ] Migration needed: no
- [x] Affects existing behavior: only the loud missing-PII-mapping report (was silent no-op)

## Skip List
- `tests/fixtures/mode_composer_selftest.py` + `mode_fixture_agent.md` — test fixtures, not production surface
- `.prd/` / `.design/` docs — plan of record, already approved via bb-prd/bb-design

## CI Coverage
- Structural agent checks (`scripts/test_agent.py` against `tests/quality_metrics.yaml`, now incl. mode checks)
- Eval harness (`evals/run_experiment.py` — roi-financial-modeler unit 1.000; pipeline 1.000; gate is BLOCKING post-#92)
- Governance hooks (anonymize-guard, checkpoint, journal)

## Testing
- 17-check composer self-test (fixture agent, both modes, error paths) — all green
- Byte-identical capping proof across 6+ synthetic configs (old vs moved implementation)
- Deanon: missing-mapping → no file modified + loud report; with mapping → placeholders restored
- Per-ticket verify (test_agent + unit + pipeline evals) ran green after each of the three tickets
- NOT tested: live agent invocation through the mode path (deliberately — dormant until #105)

## Base-branch note
Based on `mariamt/20260722-fix-roi-eval-gate` (PR #92) — stacked because the verify story depends on #92's re-pointed goldens + BLOCKING gate. When #92 merges, GitHub retargets this PR to `main` automatically.
