### PR TITLE
feat(skill-first): PR 2 — ROI gate wiring + parity eval (#104)

### DIFF
--- a/.claude/commands/build-roi.md
+++ b/.claude/commands/build-roi.md
@@ -80,18 +80,38 @@ Produce:
 
 Wait for completion.
 
-### 5. Review and Generate Excel
+### 5. Run the Reasonableness Gate
 
-Present the financial model summary to the consultant (NPV, ROI, payback, per-lever breakdown).
+Standalone `/build-roi` runs get the same reasonableness guarantee as a full pipeline run — the cap gate is not optional and not skippable just because there's no orchestrator in the loop.
+
+Immediately after the financial modeler writes `{outputs_dir}/roi_config.json`, run the gate via Bash:
+
+```
+python3 scripts/artifact_boundary.py cap {outputs_dir}/roi_config.json
+```
+
+This caps any `backbase_impact` value over 60% in place (idempotent — safe to re-run) and prints a JSON gate report. Surface a **one-line gate report** to the consultant before moving on, derived from that JSON:
+
+- If `modified: true`, summarize each capped value from `warnings`, e.g.: *"Gate: backbase_impact capped 0.72 → 0.60 on L3_retention (2 more capped — see full report)."*
+- If `modified: false` and `warnings` is empty: *"Gate: no changes — within bounds."*
+- If `modified: false` but `warnings` is non-empty (e.g. a curve-adjusted ROI outside the segment benchmark range): surface that warning too — it's not a cap violation, but it's exactly the kind of thing a consultant should see before presenting the number.
+
+Do not silently swallow the gate output — if `roi_config.json` doesn't exist or fails to parse, stop and flag it rather than proceeding to Excel generation with an unverified config.
+
+### 6. Review and Generate Excel
+
+Present the financial model summary to the consultant (NPV, ROI, payback, per-lever breakdown), including the one-line gate report from step 5.
 
 If approved, optionally run `/generate-roi-excel` to produce the Excel workbook:
 ```
 /generate-roi-excel
 ```
 
+(`/generate-roi-excel` re-runs the same cap gate itself before generating — it's idempotent, so this is a no-op if step 5 already capped the config. It exists as a skill-level backstop so an uncapped config can never reach Excel, even if `/generate-roi-excel` is invoked on a `roi_config.json` from somewhere other than this flow.)
+
 ### Shortcut: Skip to Financial Modeler
 
-If the consultant already has a lever list (from a previous run, manual work, or another source), skip steps 2-3 and go directly to step 4. The financial modeler accepts any `lever_candidates.md` that follows the expected format.
+If the consultant already has a lever list (from a previous run, manual work, or another source), skip steps 2-3 and go directly to step 4. The financial modeler accepts any `lever_candidates.md` that follows the expected format. Step 5 (the gate) still applies regardless of how `roi_config.json` was produced.
 
 ### Output Files
 
@@ -100,5 +120,5 @@ If the consultant already has a lever list (from a previous run, manual work, or
 | `lever_candidates.md` | Validated lever list with four-link chains |
 | `CHECKPOINT_roi_levers.md` | Lever checkpoint for audit trail |
 | `roi_report.md` | Full analytical ROI report |
-| `roi_config.json` | Structured config for Excel generation |
+| `roi_config.json` | Structured config for Excel generation (capped by the reasonableness gate — step 5) |
 | `*_ROI_Model.xlsx` | Excel workbook (if /generate-roi-excel invoked) |

--- a/.claude/commands/generate-roi-excel.md
+++ b/.claude/commands/generate-roi-excel.md
@@ -76,11 +76,21 @@ When this skill is invoked:
    - Define three scenarios with different impact assumptions
    - Document all assumptions with sources
 
-3. **Generate the Model:**
+3. **Run the Reasonableness Gate (MANDATORY — before generating):**
+   - An uncapped `roi_config.json` must never reach Excel, regardless of whether it came from `/build-roi`, the full pipeline, or a config assembled by hand for this skill.
+   - Run via Bash, on whatever JSON config file backs this run (write the config to disk first if it was only assembled in-memory):
+     ```
+     python3 scripts/artifact_boundary.py cap <path-to-roi_config.json>
+     ```
+   - The gate is idempotent — if `/build-roi` (or the pipeline) already ran it, this is a no-op; running it twice never double-caps.
+   - Report a one-line gate summary to the consultant before generating, e.g. *"Gate: backbase_impact capped 0.72 → 0.60 on L3_retention"* or *"Gate: no changes — within bounds."* If the gate reports any other warnings (e.g. curve-adjusted ROI outside the segment benchmark range), surface those too.
+   - Re-read the (possibly now-capped) config from disk before proceeding to step 4 — generate from the gated file, not from a pre-gate in-memory copy.
+
+4. **Generate the Model:**
    - Use the ROIModelGenerator class from tools/roi_excel_generator.py
    - Save to the outputs folder with client name in filename
 
-4. **Validate Output:**
+5. **Validate Output:**
    - Open the Excel file and verify formulas work
    - Check that scenarios produce different results
    - Ensure all assumptions are documented

--- a/evals/goldens/roi_config_overcap.json
+++ b/evals/goldens/roi_config_overcap.json
@@ -1,0 +1,610 @@
+{
+  "client_name": "Meridian Mutual Bank (OVERCAP EVAL FIXTURE)",
+  "bank_name": "Meridian Mutual Bank",
+  "date": "2026-06-22",
+  "currency": "AUD",
+  "industry": "Retail Banking",
+  "country": "Northland",
+  "analysis_years": 5,
+  "discount_rate": 0.1,
+  "selected_scenario": "moderate",
+  "total_investment": 1500000,
+  "basic_information": {
+    "total_fte": 95,
+    "total_fte_confidence": "HIGH",
+    "total_fte_source": "Client follow-up — CLIENT-CONFIRMED",
+    "annual_revenue": 250000000,
+    "annual_revenue_confidence": "LOW",
+    "annual_revenue_source": "Prior-year model — REFRESH",
+    "cost_to_income_ratio": 0.65,
+    "cost_to_income_ratio_confidence": "LOW",
+    "cost_to_income_ratio_source": "Account plan — confirm current",
+    "operating_costs": 162500000,
+    "operating_costs_confidence": "LOW",
+    "operating_costs_source": "Derived = Annual Revenue x Cost-to-Income",
+    "total_customers": 310000,
+    "total_customers_confidence": "MEDIUM",
+    "total_customers_source": "Stakeholder interview — merged base (split a data gap)"
+  },
+  "backbase_loading": {
+    "implementation_curve": [
+      0.4,
+      0.85,
+      1.0,
+      1.0,
+      1.0
+    ],
+    "effectiveness_curve": [
+      0.34,
+      0.765,
+      0.9,
+      1.0,
+      1.0
+    ],
+    "yoy_growth": [
+      0.03,
+      0.03,
+      0.03,
+      0.03,
+      0.03
+    ],
+    "curves": {
+      "revenue": {
+        "implementation": [
+          0.4,
+          0.85,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.34,
+          0.765,
+          0.9,
+          1.0,
+          1.0
+        ]
+      },
+      "retention": {
+        "implementation": [
+          0.0,
+          0.55,
+          0.9,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.0,
+          0.495,
+          0.81,
+          1.0,
+          1.0
+        ]
+      },
+      "servicing": {
+        "implementation": [
+          0.45,
+          0.9,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.3825,
+          0.81,
+          0.9,
+          1.0,
+          1.0
+        ]
+      },
+      "it_step": {
+        "implementation": [
+          0.6,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.51,
+          0.9,
+          0.9,
+          1.0,
+          1.0
+        ]
+      },
+      "default": {
+        "implementation": [
+          0.4,
+          0.85,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "effectiveness": [
+          0.34,
+          0.765,
+          0.9,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  },
+  "scenarios": {
+    "conservative": {
+      "label": "Conservative (downside)",
+      "capture_rate": 0.3,
+      "implementation_curve": [
+        0.3,
+        0.75,
+        0.9,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.225,
+        0.6,
+        0.81,
+        1.0,
+        1.0
+      ],
+      "curves": {
+        "revenue": {
+          "implementation": [
+            0.3,
+            0.75,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.225,
+            0.6,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "retention": {
+          "implementation": [
+            0.0,
+            0.45,
+            0.8,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.0,
+            0.36,
+            0.72,
+            1.0,
+            1.0
+          ]
+        },
+        "servicing": {
+          "implementation": [
+            0.35,
+            0.8,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.2625,
+            0.64,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "it_step": {
+          "implementation": [
+            0.5,
+            0.9,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.375,
+            0.72,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "default": {
+          "implementation": [
+            0.3,
+            0.75,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.225,
+            0.6,
+            0.81,
+            1.0,
+            1.0
+          ]
+        }
+      },
+      "backbase_impacts": {
+        "L1_deposit_activation": 0.3,
+        "L2_cross_sell": 0.1364,
+        "L3_retention": 0.07,
+        "L4a_call_containment": 0.3,
+        "L4b_aht_reduction": 0.15,
+        "L5_Northgate_scalability": 0.3,
+        "L6_vendor_consolidation": 0.85
+      },
+      "summary": {
+        "npv": "$1.4M",
+        "roi": "48%",
+        "payback": "3.1 yrs",
+        "benefits": "$7.6M",
+        "desc": "Below the retail floor — the expected downside. Capture 0.30, slower ramp, lower adoption."
+      }
+    },
+    "moderate": {
+      "label": "Moderate (BASE CASE)",
+      "capture_rate": 0.4,
+      "implementation_curve": [
+        0.4,
+        0.85,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.34,
+        0.765,
+        0.9,
+        1.0,
+        1.0
+      ],
+      "curves": {
+        "revenue": {
+          "implementation": [
+            0.4,
+            0.85,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.34,
+            0.765,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "retention": {
+          "implementation": [
+            0.0,
+            0.55,
+            0.9,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.0,
+            0.495,
+            0.81,
+            1.0,
+            1.0
+          ]
+        },
+        "servicing": {
+          "implementation": [
+            0.45,
+            0.9,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.3825,
+            0.81,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "it_step": {
+          "implementation": [
+            0.6,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.51,
+            0.9,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "default": {
+          "implementation": [
+            0.4,
+            0.85,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.34,
+            0.765,
+            0.9,
+            1.0,
+            1.0
+          ]
+        }
+      },
+      "backbase_impacts": {
+        "L1_deposit_activation": 0.4,
+        "L2_cross_sell": 0.2273,
+        "L3_retention": 0.11,
+        "L4a_call_containment": 0.4,
+        "L4b_aht_reduction": 0.2,
+        "L5_Northgate_scalability": 0.4,
+        "L6_vendor_consolidation": 0.85
+      },
+      "summary": {
+        "npv": "$4.3M",
+        "roi": "120%",
+        "payback": "1.9 yrs",
+        "benefits": "$11.5M",
+        "desc": "Base case — 121% ROI inside the retail benchmark (100–150%); 96% without L6 (at floor, stands alone). Capture 0.40."
+      }
+    },
+    "aggressive": {
+      "label": "Aggressive (UPSIDE — labelled optionality)",
+      "capture_rate": 0.5,
+      "implementation_curve": [
+        0.5,
+        0.95,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "effectiveness_curve": [
+        0.475,
+        0.95,
+        0.95,
+        1.0,
+        1.0
+      ],
+      "curves": {
+        "revenue": {
+          "implementation": [
+            0.5,
+            0.95,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.475,
+            0.95,
+            0.95,
+            1.0,
+            1.0
+          ]
+        },
+        "retention": {
+          "implementation": [
+            0.1,
+            0.65,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.095,
+            0.65,
+            0.9,
+            1.0,
+            1.0
+          ]
+        },
+        "servicing": {
+          "implementation": [
+            0.55,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.5225,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ]
+        },
+        "it_step": {
+          "implementation": [
+            0.7,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.665,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ]
+        },
+        "default": {
+          "implementation": [
+            0.5,
+            0.95,
+            1.0,
+            1.0,
+            1.0
+          ],
+          "effectiveness": [
+            0.475,
+            0.95,
+            0.95,
+            1.0,
+            1.0
+          ]
+        }
+      },
+      "backbase_impacts": {
+        "L1_deposit_activation": 0.5,
+        "L2_cross_sell": 0.3636,
+        "L3_retention": 0.18,
+        "L4a_call_containment": 0.5,
+        "L4b_aht_reduction": 0.25,
+        "L5_Northgate_scalability": 0.5,
+        "L6_vendor_consolidation": 0.85
+      },
+      "summary": {
+        "npv": "$8.8M",
+        "roi": "235%",
+        "payback": "1.1 yrs",
+        "benefits": "$17.6M",
+        "desc": "Above the range max — 'if-all-goes-right' upside, NOT the expected case. Capture 0.50, fast-track, high adoption."
+      }
+    }
+  },
+  "investment": {
+    "license": {
+      "year_1": 300000,
+      "year_2": 300000,
+      "year_3": 300000,
+      "year_4": 300000,
+      "year_5": 300000
+    },
+    "implementation": {
+      "year_1": 300000,
+      "year_2": 0,
+      "year_3": 0,
+      "year_4": 0,
+      "year_5": 0
+    },
+    "notes": "trimmed eval fixture"
+  },
+  "investment_schedule": {
+    "license": {
+      "year_1": 300000,
+      "year_2": 300000,
+      "year_3": 300000,
+      "year_4": 300000,
+      "year_5": 300000
+    },
+    "implementation": {
+      "year_1": 300000,
+      "year_2": 0,
+      "year_3": 0,
+      "year_4": 0,
+      "year_5": 0
+    }
+  },
+  "value_lever_groups": {
+    "L1_deposit_activation": {
+      "group_name": "Deposit Activation & Funded-Balance Growth (NII)",
+      "category": "Revenue Growth — Deposit/NII",
+      "lifecycle_stage": "Activate",
+      "lever_type": "revenue_uplift",
+      "evidence_ids": [
+        "PB-ComparableBackbase-FundedAccts-69pct",
+        "PACK-3.3-DepositEcon",
+        "PACK-3.1-Engagement"
+      ],
+      "revenue_drivers": {
+        "funded_balance_nii": {
+          "name": "Funded-Balance Activation NII (Premium in-app + Wallets)",
+          "type": "Revenue",
+          "description": "Activate active-but-unfunded relationships toward funded BonusSaver balances; gap-based on SaverPlus funding 40.6% vs a comparable Backbase customer (US regional bank) 69% funded; incremental funded balance × NII margin.",
+          "baseline_annual": 2469481.0,
+          "potential_annual_benefit": 987792.0,
+          "inputs": {
+            "customers_merged": {
+              "value": 281000,
+              "unit": "customers",
+              "source": "Stakeholder S1 — Meridian n + Northgate n (split a data gap)",
+              "confidence": "MEDIUM",
+              "assumption": "Merged customer base the in-app experience can reach.",
+              "fmt": "#,##0"
+            },
+            "active_txn_rate": {
+              "value": 0.4,
+              "unit": "ratio",
+              "source": "Deck headroom stat",
+              "confidence": "MEDIUM",
+              "assumption": "Share of customers with an ACTIVE transaction account.",
+              "fmt": "0.0%"
+            },
+            "addressable_active": {
+              "value": 112400.0,
+              "unit": "customers",
+              "source": "Stakeholder S1 / deck stats",
+              "confidence": "MEDIUM",
+              "assumption": "In-app-reachable engaged base = customers × active-txn rate.",
+              "formula": "{customers_merged} * {active_txn_rate}",
+              "fmt": "#,##0"
+            },
+            "backbase_impact": {
+              "value": 0.75,
+              "unit": "ratio",
+              "source": "Eval fixture — deliberately over-cap (ticket #104 negative)",
+              "confidence": "LOW",
+              "assumption": "Overstated Backbase attribution used to exercise the cap gate.",
+              "fmt": "0%"
+            }
+          }
+        }
+      }
+    }
+  },
+  "assumptions_register": [
+    {
+      "assumption": "Merged customer base used across levers",
+      "confidence": "MEDIUM",
+      "owner": "Client Finance",
+      "note": "part of the Assumptions Register"
+    }
+  ],
+  "data_gaps_for_validation": [
+    {
+      "gap": "Exact Meridian/Northgate customer split",
+      "impact": "affects L1/L2/L3 baselines"
+    }
+  ],
+  "bank_profile": {
+    "name": "Meridian Mutual Bank",
+    "type": "Tier-3 regional mutual (mid-merger with Northgate)",
+    "region": "Northland (Riverport, Central)",
+    "country": "Northland",
+    "total_revenue": 152430000,
+    "total_customers": 281000,
+    "total_fte": 94
+  },
+  "sources": [
+    {
+      "ref": "Meridian data export",
+      "detail": "Account funding rates & avg balances (SaverPlus 40.6%/$3,705, BonusSaver 66.4%/$29,708); IB n & App n monthly actives.",
+      "file": "Digital Data for BackBase.xlsx"
+    },
+    {
+      "ref": "Meridian CC actuals",
+      "detail": "Contact-centre call volumes + AHT by wrap-up code, n calls/yr; FTE counts CC 28 / Branch 66.",
+      "file": "6 month Data.xlsx"
+    }
+  ],
+  "sensitivity_notes": "Sensitivity analysis: a +/-25% swing in the funding-gap assumption moves L1 benefit by roughly the same proportion."
+}

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -76,8 +76,23 @@ components:
     # fix was built on). Re-pointed from a never-created `nfis` golden — see PRD v1.
     input: evals/goldens/roi_config_provenance.json
     code: [three_scenarios, npv_payback_present, assumptions_register_present, sensitivity_analysis_present,
-           basic_information_has_sources_list, basic_fields_have_source_and_confidence, operating_costs_emitted_as_formula]
+           basic_information_has_sources_list, basic_fields_have_source_and_confidence, operating_costs_emitted_as_formula,
+           backbase_impact_within_cap, overcap_negative_gate_witness]
     judge: [conservative_bias, topdown_bottomup_correlation]
+    # #104 parity case (standalone /build-roi + /generate-roi-excel now run the
+    # same artifact_boundary.py cap_roi_config gate the pipeline runs, #102):
+    #   - goldens: roi_config_provenance.json above (the wired `input:`) is
+    #     already capped — `backbase_impact_within_cap` must PASS on it.
+    #   - negatives: evals/goldens/roi_config_overcap.json — a >0.60 backbase_impact
+    #     (driver-level + scenario-level) with scenario numbers that push the
+    #     curve-adjusted 5-yr ROI (279%) outside the Retail Banking benchmark
+    #     (100-150%). Like roi-excel-generator's `sources_sheet_absent_when_unset`
+    #     below, `components:` altitude only wires ONE `input:` per component (no
+    #     goldens:/negatives: list the way `deliverables:` gets — see run_experiment.py),
+    #     so `overcap_negative_gate_witness` loads this fixture directly: proves it
+    #     FAILS `backbase_impact_within_cap` pre-gate, then gates a /tmp COPY of it
+    #     (scripts/artifact_boundary.py cap_roi_config — never mutates the committed
+    #     fixture) and proves the capped copy PASSES the same invariant.
 
   # roi-excel-generator (#85) — verifies the GENERATOR actually renders the
   # provenance contract the roi-financial-modeler agent emits (#83 generator,

--- a/evals/rubrics/component/specifics.py
+++ b/evals/rubrics/component/specifics.py
@@ -28,9 +28,10 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
 
-from rubrics.base import CheckResult
+from rubrics.base import CheckResult, repo_root
 from rubrics.component import governance
 from rubrics.judge.judge import judge
 
@@ -156,6 +157,19 @@ def _market_context(text: str) -> list[CheckResult]:
 # ---------------------------------------------------------------------------
 _VALID_CONFIDENCE = {"HIGH", "MEDIUM", "LOW", "ASSUMPTION"}
 
+# Ticket #104 (A4 — ROI gate wiring in the ROI skills) — parity eval case.
+# Standalone /build-roi and /generate-roi-excel runs now run the SAME cap gate
+# (scripts/artifact_boundary.py cap_roi_config, ticket #102) that orchestrate.py
+# already runs. These checks give the roi-financial-modeler component gate a
+# "capped invariant": no backbase_impact value (driver-level in
+# value_lever_groups, or scenario-level in scenarios[*].backbase_impacts) may
+# exceed MAX_BACKBASE_IMPACT. We deliberately do NOT reuse cap_roi_config's own
+# `passed` flag here — that flag also folds in the ROI-range/revenue-ratio
+# reasonableness warnings (heuristic, not "capped"), and the wired golden
+# (a trimmed fixture with near-zero modeled benefit) trips those unrelated
+# warnings regardless of capping. The invariant below isolates exactly what
+# the gate is contractually supposed to guarantee: values <= the cap.
+
 
 def _try_parse_json(text: str) -> dict | None:
     try:
@@ -163,6 +177,61 @@ def _try_parse_json(text: str) -> dict | None:
         return data if isinstance(data, dict) else None
     except (json.JSONDecodeError, ValueError):
         return None
+
+
+def _backbase_impact_values(data: dict) -> list[float]:
+    """Collect every backbase_impact-like numeric value from a roi_config,
+    walking the exact same paths scripts.artifact_boundary.cap_roi_config caps:
+    driver-level `value_lever_groups.*.{revenue,cost}_drivers.*.inputs.backbase_impact`
+    and scenario-level `scenarios.*.backbase_impacts.*`."""
+    vals: list[float] = []
+    groups = data.get("value_lever_groups", data.get("journeys", {}))
+    if isinstance(groups, dict):
+        for group in groups.values():
+            if not isinstance(group, dict):
+                continue
+            for driver_type in ("revenue_drivers", "cost_drivers"):
+                for driver in group.get(driver_type, {}).values():
+                    if not isinstance(driver, dict):
+                        continue
+                    bi = driver.get("inputs", {}).get("backbase_impact", {})
+                    val = bi.get("value") if isinstance(bi, dict) else bi if isinstance(bi, (int, float)) else None
+                    if isinstance(val, (int, float)):
+                        vals.append(float(val))
+    scenarios = data.get("scenarios", {})
+    if isinstance(scenarios, dict):
+        for sc in scenarios.values():
+            if not isinstance(sc, dict):
+                continue
+            for imp_val in sc.get("backbase_impacts", {}).values():
+                if isinstance(imp_val, (int, float)):
+                    vals.append(float(imp_val))
+    return vals
+
+
+def _max_backbase_impact() -> float:
+    """Import the cap constant from the gate itself (scripts/artifact_boundary.py,
+    #102) rather than hard-coding a duplicate — if the gate's threshold ever
+    changes, this invariant tracks it automatically."""
+    root = repo_root()
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from scripts.artifact_boundary import MAX_BACKBASE_IMPACT
+    return MAX_BACKBASE_IMPACT
+
+
+def _capped_invariant(data: dict) -> tuple[bool, str]:
+    """True iff every backbase_impact value in `data` is within the gate's cap."""
+    try:
+        cap = _max_backbase_impact()
+    except ImportError as e:
+        return True, f"scripts.artifact_boundary not importable — skipping cap check ({e})"
+    vals = _backbase_impact_values(data)
+    over = [v for v in vals if v > cap]
+    ok = len(over) == 0
+    detail = (f"{len(vals)} backbase_impact value(s) checked, all <= {cap:.0%}" if ok
+              else f"{len(over)} value(s) exceed the {cap:.0%} cap: {over}")
+    return ok, detail
 
 
 def _roi_modeler(text: str) -> list[CheckResult]:
@@ -225,7 +294,65 @@ def _roi_modeler(text: str) -> list[CheckResult]:
     out.append(_bool_check("operating_costs_emitted_as_formula", ok_oc,
                            detail=f"revenue/cost-to-income/operating_costs trio present={has_trio}, "
                                   f"operating_costs_source notes derivation={notes_derivation} ({oc_source!r})"))
+
+    # --- #104 parity case: standalone /build-roi and /generate-roi-excel now run
+    # the same artifact_boundary cap gate the pipeline runs. The wired golden
+    # (roi_config_provenance.json) is already capped and must PASS this invariant.
+    ok_cap, cap_detail = _capped_invariant(data)
+    out.append(_bool_check("backbase_impact_within_cap", ok_cap, detail=cap_detail))
+    out.append(_check_overcap_negative_gated())
     return out
+
+
+_OVERCAP_NEGATIVE_GOLDEN = "evals/goldens/roi_config_overcap.json"
+
+
+def _check_overcap_negative_gated() -> CheckResult:
+    """Witness check (same pattern as roi_excel_generator._check_sources_sheet_absent_when_unset):
+    registry.yaml's `components:` altitude wires only ONE `input:` target, so the
+    NEGATIVE fixture (evals/goldens/roi_config_overcap.json) is exercised here
+    directly rather than through a registry `negatives:` list. Proves both halves
+    of the #104 parity contract in one deterministic check:
+      1. the negative, AS COMMITTED, FAILS the capped invariant (an over-cap
+         backbase_impact value is actually present — the fixture is genuinely bad).
+      2. running the real gate (scripts.artifact_boundary.cap_roi_config) on a
+         COPY of it (never mutating the committed fixture) produces a config that
+         PASSES the same invariant.
+    """
+    name = "overcap_negative_gate_witness"
+    root = repo_root()
+    fixture = root / _OVERCAP_NEGATIVE_GOLDEN
+    if not fixture.exists():
+        return _bool_check(name, False, detail=f"fixture not found: {fixture}")
+    try:
+        pre_data = json.loads(fixture.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        return _bool_check(name, False, detail=f"could not read/parse fixture: {e}")
+
+    pre_ok, pre_detail = _capped_invariant(pre_data)
+    if pre_ok:
+        return _bool_check(name, False,
+                           detail=f"negative fixture did NOT fail pre-gate (expected an over-cap value): {pre_detail}")
+
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    try:
+        from scripts.artifact_boundary import cap_roi_config
+    except ImportError as e:
+        return _bool_check(name, False, detail=f"scripts.artifact_boundary not importable: {e}")
+
+    import shutil
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        tmp_copy = Path(td) / "roi_config_overcap.json"
+        shutil.copy(fixture, tmp_copy)
+        cap_roi_config(str(tmp_copy))  # gates the COPY in place; committed fixture untouched
+        post_data = json.loads(tmp_copy.read_text())
+
+    post_ok, post_detail = _capped_invariant(post_data)
+    ok = pre_ok is False and post_ok
+    detail = f"pre-gate FAILED as expected ({pre_detail}); post-gate (on a /tmp copy) {'PASSED' if post_ok else 'still FAILED'} ({post_detail})"
+    return _bool_check(name, ok, detail=detail)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PR 2 of the Skill-First Phase 1 cycle (Epic #98): standalone ROI runs now get the same reasonableness guarantee as pipeline runs. `/build-roi` caps `roi_config.json` right after the modeler writes it; `/generate-roi-excel` re-runs the (idempotent) gate before generating, so an uncapped config can never reach Excel. A parity eval case proves the guarantee.

## Tickets
- Closes #104 — A4: ROI gate wiring in /build-roi + /generate-roi-excel + parity eval case

## Approach
- Skill wiring is instruction text: both commands invoke `python3 scripts/artifact_boundary.py cap <path>` (the CLI landed in #102 / PR #116) and surface a one-line gate report to the consultant.
- Parity eval: `backbase_impact_within_cap` (golden must carry no impact > 0.60) + `overcap_negative_gate_witness` (loads the new `roi_config_overcap.json` negative, proves it fails pre-gate, gates a tempdir copy through the real `cap_roi_config`, proves it passes post-gate).
- The negative is exercised as a witness check inside the rubric rather than a registry `negatives:` list — component-altitude rows support a single `input:` target only (verified in `run_experiment.py`; same idiom as `roi_excel_generator.py`'s sibling-fixture checks from PRD v1).

## Focus Areas
- Integration: `generate-roi-excel.md` step 3 must cover the hand-supplied-config path (it does — in-memory configs are written to disk, gated, and re-read before generation).
- Edge cases: gate report branching (modified / clean / warnings-only) in `build-roi.md` step 5.

## Risk Flags
- [ ] Breaking changes: no
- [ ] Migration needed: no
- [x] Affects existing behavior: standalone ROI configs are now capped (that is the point); previously uncapped standalone output was the defect

## Skip List
- `evals/goldens/roi_config_overcap.json` — deliberately unreasonable fixture (impacts 0.75/0.85); it is SUPPOSED to look wrong

## CI Coverage
- roi-financial-modeler unit row now 9 checks incl. the two parity checks (1.000 local)
- Pipeline altitude 1.000; structural checks green

## Testing
- Negative demonstrated failing standalone (4 values over cap) and passing after gating a /tmp copy; committed fixture never mutated
- All three verify commands exit 0 post-commit
- NOT tested: a live /build-roi run end-to-end (skill instruction change; the gate CLI itself was proven in PR #116)

## Base-branch note
Stacked on `mariamt/20260724-skill-first-contracts` (PR #116). Review order: #92 → #116 → this.
