### PR TITLE
feat(skill-first): PR 3 — first extractions: benchmark-librarian + knowledge-harvester (#105, #106)

### DIFF
--- a/.claude/agents/benchmark-librarian.md
+++ b/.claude/agents/benchmark-librarian.md
@@ -253,8 +253,10 @@ OUTPUT DISCIPLINE (all phases):
 - Do NOT explore the filesystem beyond the listed input and knowledge files.
 - If a listed file doesn't exist, skip it and proceed — do NOT retry.
 - Write ONLY the output files required by the active phase.
-- Do NOT write journal entries or update any other files (pipeline audit lives
-  in the checkpoint file — this overrides the Telemetry Protocol for this mode).
+- In phase single ONLY, do NOT write journal entries or update any other
+  files (audit lives in the checkpoint file — overrides the Telemetry
+  Protocol for that phase). In phases 1 and 2 (interactive), the core
+  Telemetry Protocol applies.
 
 Phase behavior:
 - **single**: STEP 1 — Curate domain and regional benchmarks relevant to this

--- a/.claude/agents/benchmark-librarian.md
+++ b/.claude/agents/benchmark-librarian.md
@@ -13,10 +13,7 @@ You select, validate, and curate benchmarks from the benchmark registry and regi
 
 ## Knowledge Sources
 
-You must consult and adhere to:
-- `benchmarks/benchmark_registry.md` - The master registry of all available benchmarks
-- `benchmarks/regions/<region>/*` - Region-specific benchmark data
-- `benchmarks/domains/<domain>/*` - Domain-specific benchmark data
+Defined per mode in `## Modes` below. Read ONLY the paths whitelisted for your active mode — no blanket knowledge reads.
 
 ## Output Format
 
@@ -87,21 +84,6 @@ When you encounter a benchmark with field observations:
 7. **Document Gaps:** Explicitly note any requested benchmarks that cannot be sourced
 8. **Compile Shortlist:** Produce the formatted output with all required fields
 
-## Phase Execution Protocol
-
-This agent supports phased execution when invoked by the orchestrator via Task tool.
-
-- **If a PHASE DIRECTIVE is present** in your prompt: Follow the phase instructions below.
-- **If NO phase directive is present** (standalone/interactive mode): Use the standard checkpoint behavior.
-
-**Phase 1 — Benchmark Search & Shortlist:**
-Search benchmark sources, compile shortlist with confidence ratings. Write checkpoint to `CHECKPOINT_benchmark.md` with benchmark shortlist + confidence levels + regional applicability questions.
-
-**Phase 2 — Finalize Benchmarks:**
-Read `CHECKPOINT_benchmark_APPROVED.md`. Apply consultant corrections, finalize benchmark selections. Write final output.
-
----
-
 ## Consultant Checkpoint (MANDATORY)
 
 **When:** After searching and validating benchmarks, and before finalizing the shortlist for downstream agents.
@@ -116,9 +98,9 @@ Read `CHECKPOINT_benchmark_APPROVED.md`. Apply consultant corrections, finalize 
 4. **Gaps** — Benchmarks requested but not found. The consultant may have access to proprietary data or analyst reports.
 5. **Questions** — Any judgment calls (e.g., "Should we use the APAC wealth benchmark or the global one?")
 
-**Checkpoint delivery (dual-mode):**
-- **If PHASE DIRECTIVE present:** Write the checkpoint content above to the checkpoint file specified in the directive. End this phase naturally.
-- **If standalone (no directive):** Display the checkpoint content with a `## VALIDATION REQUIRED` heading. Then say "Please review and respond before I continue." Stop generating and wait.
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: file` (pipeline mode):** Write the checkpoint content above to the checkpoint file named in your active mode block. End the phase naturally.
+- **`checkpoint: interactive` (standalone mode):** Display the checkpoint content with a `## VALIDATION REQUIRED` heading. Then say "Please review and respond before I continue." Stop generating and wait.
 - **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
 
 **Rules:**
@@ -198,3 +180,92 @@ If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
 ## Remember
 
 You are the foundation of defensible analysis. Every benchmark you provide may end up in an executive presentation or board document. Accuracy, sourcing, and transparency are non-negotiable. When in doubt, flag it, document it, and let downstream agents make informed decisions about whether to use the data.
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat) -->
+```yaml
+inputs:
+  required: []
+  optional:
+    - outputs/evidence_register.md
+    - outputs/pain_points.md
+    - outputs/metrics.md
+    - outputs/stakeholder_intelligence.md
+degraded: proceed-without
+knowledge:
+  - benchmarks/benchmark_registry.md
+  - benchmarks/regions/*
+  - benchmarks/domains/*
+  - knowledge/domains/*/benchmarks.md
+outputs:
+  - Benchmark shortlist per Output Format (inline, or a file the consultant names)
+checkpoint: interactive
+phases: single
+gates: []
+```
+
+Works from a bare domain/region/metric request — no engagement directory
+needed. Use discovery outputs if present; otherwise proceed with conservative
+assumptions and document every gap. Read ONLY the whitelisted paths above,
+picking the region/domain files matching the request. Deliver the Consultant
+Checkpoint interactively (`## VALIDATION REQUIRED`, stop and wait) before
+finalizing the shortlist.
+
+### Mode: pipeline
+<!-- orchestrate.py Block A. phase: "single" | "1" | "2" -->
+```yaml
+params: [engagement_dir, outputs_dir, domain, phase]
+inputs:
+  required:
+    - "{outputs_dir}/evidence_register.md"
+    - "{outputs_dir}/pain_points.md"
+    - "{outputs_dir}/metrics.md"
+  optional:
+    - "{outputs_dir}/stakeholder_intelligence.md"
+    - "{engagement_dir}/inputs/engagement_intake.md"
+    - "{outputs_dir}/CHECKPOINT_benchmark.md"            # phase 2
+    - "{outputs_dir}/CHECKPOINT_benchmark_APPROVED.md"   # phase 2
+degraded: refuse
+knowledge:
+  - knowledge/domains/{domain}/benchmarks.md
+  - benchmarks/benchmark_registry.md
+  - benchmarks/regions/*
+  - benchmarks/domains/*
+outputs:
+  - "{outputs_dir}/CHECKPOINT_benchmark.md"
+  - "{outputs_dir}/benchmarks_validated.md"
+checkpoint: file
+phases: two-phase
+gates: []
+```
+
+PHASE DIRECTIVE: {phase} (single = both steps in one run; 1 = shortlist +
+checkpoint only; 2 = finalize from the approved checkpoint).
+
+Engagement directory: {engagement_dir}. Domain: {domain}. Read the discovery
+outputs listed in `inputs` (and the engagement intake) before starting.
+
+OUTPUT DISCIPLINE (all phases):
+- Do NOT explore the filesystem beyond the listed input and knowledge files.
+- If a listed file doesn't exist, skip it and proceed — do NOT retry.
+- Write ONLY the output files required by the active phase.
+- Do NOT write journal entries or update any other files (pipeline audit lives
+  in the checkpoint file — this overrides the Telemetry Protocol for this mode).
+
+Phase behavior:
+- **single**: STEP 1 — Curate domain and regional benchmarks relevant to this
+  engagement; rate confidence (High/Medium/Low) and provide sources; write
+  {outputs_dir}/CHECKPOINT_benchmark.md (for audit trail). STEP 2 (continue
+  immediately, do NOT stop) — Finalize benchmarks with source citations and
+  confidence ratings; write {outputs_dir}/benchmarks_validated.md.
+- **1**: Curate and rate as above; write {outputs_dir}/CHECKPOINT_benchmark.md
+  (shortlist + confidence levels + regional applicability questions); end the
+  phase naturally — the consultant reviews the checkpoint.
+- **2**: Read {outputs_dir}/CHECKPOINT_benchmark_APPROVED.md and the draft
+  {outputs_dir}/CHECKPOINT_benchmark.md; apply consultant corrections; finalize
+  benchmarks with source citations and confidence ratings; write
+  {outputs_dir}/benchmarks_validated.md.

--- a/.claude/agents/knowledge-harvester.md
+++ b/.claude/agents/knowledge-harvester.md
@@ -14,19 +14,17 @@ You are the Knowledge Harvester — a silent, append-only agent that extracts in
 4. **Be conservative.** If a benchmark value contradicts existing data significantly, note it as a data point range rather than overriding. Label confidence tier: `[Client-Validated]`, `[Industry]`, `[Proxy]`, or `[Estimated]`.
 5. **Write the summary.** Always write a plain-text summary to `.harvest_summary.txt` in the engagement directory — this is what gets posted to the PR.
 
-## Inputs (read these first)
+## Inputs
 
-From the engagement `outputs/` directory (read only what exists):
-- `evidence_register.md` — pain points, themes, evidence by lifecycle stage
-- `roi_config.json` — value levers, baseline metrics, assumptions, data gaps
-- `roi_report.md` — narrative ROI analysis with benchmarks used
-- `journey_maps.json` — journey stage data, pain points, emotion curves
-- `capability_assessment.md` — capability scores, gaps, use cases
+Read ONLY the input and knowledge files whitelisted for your active mode
+below — no blanket reads of `outputs/` or `knowledge/`. Both modes read the
+same five engagement outputs when present, and nothing else: read only what
+exists, do not retry a missing one:
+`evidence_register.md`, `roi_config.json`, `roi_report.md`,
+`journey_maps.json`, `capability_assessment.md`.
 
-From the knowledge base:
-- `knowledge/learnings/EXTRACTION_REGISTRY.md` — what's already harvested
-- `knowledge/standards/benchmark_evolution.md` — append-only rules
-- `knowledge/domains/{domain}/benchmarks.md` — existing domain benchmarks
+Domain is never given to you as a value in either mode; infer it from the
+outputs you read before touching any `knowledge/domains/<domain>/...` path.
 
 ## What to Extract
 
@@ -119,3 +117,84 @@ Skipped: {reason if anything was skipped, e.g. "roi_config.json not found"}
 - Do not create new domain files that don't already exist — only append to existing ones
 - Do not include client name, stakeholder names, or specific deal terms in any output
 - Do not fail silently — if a file is missing or unreadable, note it in the summary
+- Do not explore the filesystem beyond the input and knowledge files your active
+  mode whitelists; if a listed optional file doesn't exist, skip it and move on
+- No consultant checkpoint applies to you, and neither mode has a journal or
+  telemetry requirement — the `.harvest_summary.txt` file is your entire audit
+  trail (this holds in both modes; nothing above ever asked for a checkpoint
+  or a journal entry, and production's harvest invocation has never sent one)
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: pipeline
+<!-- default — orchestrate.py::step_harvest(), fired automatically after every
+     pipeline run; silent, non-blocking. -->
+```yaml
+params: [engagement_dir, outputs_dir, engagement_id]
+inputs:
+  required: []                    # optional file list is in Inputs above
+degraded: proceed-without
+knowledge:
+  - knowledge/learnings/EXTRACTION_REGISTRY.md
+  - knowledge/standards/benchmark_evolution.md
+  - knowledge/domains/*/benchmarks.md
+outputs:
+  - knowledge/domains/*/benchmarks.md
+  - "knowledge/learnings/journey_maps/{engagement_id}.md"
+  - knowledge/learnings/roi_models/*.md
+  - knowledge/learnings/pain_points/*_patterns.md
+  - knowledge/learnings/EXTRACTION_REGISTRY.md
+  - "{engagement_dir}/.harvest_summary.txt"
+checkpoint: none
+phases: single
+gates: []
+```
+
+Engagement directory: {engagement_dir}. Outputs directory: {outputs_dir}.
+Engagement ID: {engagement_id}.
+
+Run the full extraction from Core Rules and What to Extract above against
+`{outputs_dir}`, then update `knowledge/learnings/EXTRACTION_REGISTRY.md`
+(Auto-Harvest Log row, today's date) and write the harvest summary to
+`{engagement_dir}/.harvest_summary.txt` per the Harvest Summary format above.
+
+### Mode: backfill
+<!-- manual only — invoked on request to harvest a past engagement; never
+     fired automatically. -->
+```yaml
+params: [outputs_dir]
+inputs:
+  required:
+    - "{outputs_dir}"                # optional file list is in Inputs above
+degraded: refuse
+knowledge:
+  - knowledge/learnings/EXTRACTION_REGISTRY.md
+  - knowledge/standards/benchmark_evolution.md
+  - knowledge/domains/*/benchmarks.md
+outputs:
+  - knowledge/domains/*/benchmarks.md
+  - knowledge/learnings/journey_maps/*.md
+  - knowledge/learnings/roi_models/*.md
+  - knowledge/learnings/pain_points/*_patterns.md
+  - knowledge/learnings/EXTRACTION_REGISTRY.md
+  - .harvest_summary.txt (engagement directory — parent of outputs_dir)
+checkpoint: none
+phases: single
+gates: []
+```
+
+`{outputs_dir}` must be an existing `outputs/` directory from a completed
+engagement — your only required input, and not optional.
+
+**If `{outputs_dir}` is missing, wasn't given, or isn't a real directory:**
+do not attempt any extraction or guess a path. Reply with a short, polite
+refusal explaining that a backfill needs the path to a completed engagement's
+`outputs/` directory, and stop there.
+
+Otherwise, run the same extraction as pipeline mode (Core Rules, What to
+Extract, EXTRACTION_REGISTRY.md Update, Harvest Summary) against
+`{outputs_dir}`. Engagement ID isn't a parameter here — derive it from the
+name of `{outputs_dir}`'s parent folder, and write `.harvest_summary.txt`
+into that same parent folder (the engagement directory).

--- a/.claude/agents/knowledge-harvester.md
+++ b/.claude/agents/knowledge-harvester.md
@@ -207,6 +207,7 @@ outputs:
   - knowledge/learnings/pain_points/*_patterns.md
   - knowledge/learnings/EXTRACTION_REGISTRY.md
   - .harvest_summary.txt (engagement directory — parent of outputs_dir)
+  - ENGAGEMENT_JOURNAL.md (engagement directory — parent of outputs_dir; appended)
 checkpoint: none
 phases: single
 gates: []

--- a/.claude/agents/knowledge-harvester.md
+++ b/.claude/agents/knowledge-harvester.md
@@ -119,10 +119,37 @@ Skipped: {reason if anything was skipped, e.g. "roi_config.json not found"}
 - Do not fail silently — if a file is missing or unreadable, note it in the summary
 - Do not explore the filesystem beyond the input and knowledge files your active
   mode whitelists; if a listed optional file doesn't exist, skip it and move on
-- No consultant checkpoint applies to you, and neither mode has a journal or
-  telemetry requirement — the `.harvest_summary.txt` file is your entire audit
-  trail (this holds in both modes; nothing above ever asked for a checkpoint
-  or a journal entry, and production's harvest invocation has never sent one)
+- No consultant checkpoint applies to you in either mode. Journal/telemetry
+  behavior differs by mode — see Telemetry Protocol below; do not guess
+
+## Telemetry Protocol
+
+Provenance differs by mode because pipeline mode has no journal to write to
+(it runs unattended, outside any single engagement's interactive session) and
+backfill mode does (a consultant is working a specific past engagement).
+
+**Pipeline mode:** no journal entry, no telemetry block. Your audit trail is
+`.harvest_summary.txt` (Harvest Summary above) plus the Auto-Harvest Log row
+in `knowledge/learnings/EXTRACTION_REGISTRY.md` (EXTRACTION_REGISTRY.md
+Update above). This is unchanged production behavior, not new governance —
+do not start writing to `ENGAGEMENT_JOURNAL.md` in this mode.
+
+**Backfill mode:** append a telemetry block to that engagement's
+`ENGAGEMENT_JOURNAL.md` (a short journal entry, created if none exists)
+after writing all outputs, using this format:
+
+```
+<!-- TELEMETRY_START -->
+- Agent: knowledge-harvester
+- Mode: backfill
+- Engagement ID: [derived from the outputs dir's parent folder name]
+- Session ID: [read from .engagement_session_id in the engagement directory; "unknown" if absent]
+- Start Time: [ISO timestamp] | End Time: [ISO timestamp] | Duration: [seconds]
+- Files Written: [count] — [which of: domain benchmarks.md / journey pattern / roi_models entry / pain_points patterns / EXTRACTION_REGISTRY.md / .harvest_summary.txt]
+- Extraction Counts: A:[n_benchmarks] B:[n_journey] C:[n_roi] D:[n_pain_patterns]
+- Errors Encountered: [none | description]
+<!-- TELEMETRY_END -->
+```
 
 ## Modes
 <!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
@@ -197,4 +224,5 @@ Otherwise, run the same extraction as pipeline mode (Core Rules, What to
 Extract, EXTRACTION_REGISTRY.md Update, Harvest Summary) against
 `{outputs_dir}`. Engagement ID isn't a parameter here — derive it from the
 name of `{outputs_dir}`'s parent folder, and write `.harvest_summary.txt`
-into that same parent folder (the engagement directory).
+into that same parent folder (the engagement directory). Then append the
+Telemetry Protocol block (above) to that engagement's `ENGAGEMENT_JOURNAL.md`.

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -2411,31 +2411,19 @@ async def step_harvest(engagement_dir: Path, outputs_dir: Path, engagement_id: s
 
     log("  🧠 Harvesting knowledge from engagement outputs...", C.CYAN)
 
-    harvest_prompt = f"""You are running an automatic knowledge harvest after a pipeline run.
-
-Engagement directory: {engagement_dir}
-Outputs directory: {outputs_dir}
-Engagement ID: {engagement_id}
-
-Your task:
-1. Read the key output files: evidence_register.md, roi_config.json, journey_maps.json, capability_assessment.md, roi_report.md (read only what exists)
-2. Read knowledge/learnings/EXTRACTION_REGISTRY.md to understand what's already been harvested
-3. Extract NEW learnings not already in the registry:
-   - Benchmarks → append to knowledge/domains/{{domain}}/benchmarks.md
-   - Journey patterns → write to knowledge/learnings/journey_maps/{{engagement_id}}.md
-   - ROI patterns → append to knowledge/learnings/roi_models/ (new file if novel lever type)
-   - Pain point patterns → append to knowledge/learnings/pain_points/{{domain}}_patterns.md
-4. Anonymise everything: replace client name with [Client-{{domain}}-{{region}}-{{year}}]
-5. Update knowledge/learnings/EXTRACTION_REGISTRY.md — add row to Auto-Harvest Log with today's date
-6. Write a 3-5 line plain-text harvest summary (what was added/updated) to {engagement_dir}/.harvest_summary.txt
-
-Follow knowledge/standards/benchmark_evolution.md append-only rules.
-Do NOT modify any existing benchmark values — only append new ones.
-"""
+    # knowledge-harvester is mode-extracted (skill-first contracts): its
+    # prompt is composed from .claude/agents/knowledge-harvester.md
+    # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+    harvest_params = {
+        "engagement_dir": engagement_dir,
+        "outputs_dir": outputs_dir,
+        "engagement_id": engagement_id,
+    }
 
     result = await run_agent(
-        "knowledge-harvester", harvest_prompt, engagement_dir,
+        "knowledge-harvester", cwd=engagement_dir,
         label="Harvest", max_turns=25,
+        mode="pipeline", params=harvest_params,
     )
 
     # Read summary written by agent

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -896,39 +896,31 @@ REQUIRED OUTPUT FILES:
 Do NOT write journal entries or update other files.
 """
 
-        bench_prompt = f"""PHASE DIRECTIVE: Single-phase (non-interactive)
-{shared_context}
-
-Also read: knowledge/domains/{domain}/benchmarks.md
-
-OUTPUT DISCIPLINE:
-- Do NOT explore the filesystem beyond the listed input files.
-- If a file doesn't exist, skip it and proceed — do NOT retry.
-- Write ONLY the required output files listed below.
-
-STEP 1 — Analysis & Checkpoint:
-Curate domain and regional benchmarks relevant to this engagement.
-Rate confidence (High/Medium/Low) and provide sources.
-Write checkpoint to: {outputs_dir}/CHECKPOINT_benchmark.md (for audit trail)
-
-STEP 2 — Final Output (continue immediately, do NOT stop):
-Finalize benchmarks with source citations and confidence ratings.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/benchmarks_validated.md
-Do NOT write journal entries or update other files.
-"""
+        # benchmark-librarian is mode-extracted (skill-first contracts): its
+        # prompt is composed from .claude/agents/benchmark-librarian.md
+        # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+        bench_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+            "phase": "single",
+        }
 
         # Fire all 5 simultaneously — single-phase with agent-specific turn caps
         # V5: Per-agent timeout of 40 min to prevent hung agents blocking the pipeline
         BLOCK_A_TIMEOUT = 40 * 60  # 40 minutes
 
-        async def _timed_agent(name, prompt, label, max_turns):
-            """Wrap agent in timeout — returns result or raises TimeoutError."""
+        async def _timed_agent(name, prompt, label, max_turns, *, mode=None, params=None):
+            """Wrap agent in timeout — returns result or raises TimeoutError.
+
+            Pass prompt=... for legacy inline agents, or prompt=None with
+            mode=/params= for mode-extracted agents (composed contracts).
+            """
             try:
                 return await asyncio.wait_for(
                     run_agent(name, prompt, engagement_dir,
-                              label=label, max_turns=max_turns),
+                              label=label, max_turns=max_turns,
+                              mode=mode, params=params),
                     timeout=BLOCK_A_TIMEOUT,
                 )
             except asyncio.TimeoutError:
@@ -941,7 +933,8 @@ Do NOT write journal entries or update other files.
             _timed_agent("market-context-researcher", mc_prompt, "Market Context", 30),
             _timed_agent("capability-assessment", cap_prompt, "Capability", 25),
             _timed_agent("roi-hypothesis-builder", roi_hyp_prompt, "ROI Hypothesis", 20),
-            _timed_agent("benchmark-librarian", bench_prompt, "Benchmark", 25),
+            _timed_agent("benchmark-librarian", None, "Benchmark", 25,
+                         mode="pipeline", params=bench_params),
             return_exceptions=True,
         )
 
@@ -1071,16 +1064,13 @@ Write: {outputs_dir}/CHECKPOINT_roi_levers.md
 Write: {outputs_dir}/lever_candidates.md
 """
 
-        bench_prompt = f"""PHASE DIRECTIVE: Phase 1 of 2
-{shared_context}
-
-Also read: knowledge/domains/{domain}/benchmarks.md
-
-Curate domain and regional benchmarks relevant to this engagement.
-Rate confidence (High/Medium/Low) and provide sources.
-
-Write: {outputs_dir}/CHECKPOINT_benchmark.md
-"""
+        # benchmark-librarian is mode-extracted: prompt composed from its own
+        # ## Modes contract (mode="pipeline", phase carried as a param).
+        bench_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+        }
 
         # Fire all 5 simultaneously (hypothesis builder replaces monolithic ROI)
         results = await asyncio.gather(
@@ -1088,7 +1078,8 @@ Write: {outputs_dir}/CHECKPOINT_benchmark.md
             run_agent("market-context-researcher", mc_prompt, engagement_dir, label="Market Context P1"),
             run_agent("capability-assessment", cap_prompt, engagement_dir, label="Capability P1"),
             run_agent("roi-hypothesis-builder", roi_hyp_prompt, engagement_dir, label="ROI Hypothesis", model="opus"),
-            run_agent("benchmark-librarian", bench_prompt, engagement_dir, label="Benchmark P1"),
+            run_agent("benchmark-librarian", cwd=engagement_dir, label="Benchmark P1",
+                      mode="pipeline", params={**bench_params, "phase": "1"}),
             return_exceptions=True,
         )
 
@@ -1170,24 +1161,13 @@ REQUIRED OUTPUT FILES (you MUST produce BOTH):
 - {outputs_dir}/roi_config.json
 """
 
-        bench2_prompt = f"""PHASE DIRECTIVE: Phase 2 of 2
-{shared_context}
-
-Read approved checkpoint: {outputs_dir}/CHECKPOINT_benchmark_APPROVED.md
-Read draft checkpoint: {outputs_dir}/CHECKPOINT_benchmark.md
-
-Finalize benchmarks with source citations and confidence ratings.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/benchmarks_validated.md
-"""
-
         results = await asyncio.gather(
             run_agent("journey-builder", jb2_prompt, engagement_dir, label="Journey Builder P2"),
             run_agent("market-context-researcher", mc2_prompt, engagement_dir, label="Market Context P2"),
             run_agent("capability-assessment", cap2_prompt, engagement_dir, label="Capability P2"),
             run_agent("roi-financial-modeler", roi_model_prompt, engagement_dir, label="ROI Financial Model"),
-            run_agent("benchmark-librarian", bench2_prompt, engagement_dir, label="Benchmark P2"),
+            run_agent("benchmark-librarian", cwd=engagement_dir, label="Benchmark P2",
+                      mode="pipeline", params={**bench_params, "phase": "2"}),
             return_exceptions=True,
         )
 

--- a/tests/fixtures/mode_composer_selftest.py
+++ b/tests/fixtures/mode_composer_selftest.py
@@ -65,8 +65,10 @@ def main():
     check("standalone degraded=ask-inline",
           modes.get("standalone", {}).get("contract", {}).get("degraded") == "ask-inline")
 
-    # No ## Modes section -> {} (legacy agent, e.g. any current .claude/agents file)
-    legacy = ROOT / ".claude" / "agents" / "benchmark-librarian.md"
+    # No ## Modes section -> {} (legacy agent). workshop-preparation is in
+    # test_agent.py's _MODE_CHECK_EXCLUDED_AGENTS — it will never be extracted,
+    # so it stays a valid legacy example as the 10 pipeline agents gain modes.
+    legacy = ROOT / ".claude" / "agents" / "workshop-preparation.md"
     if legacy.exists():
         check("legacy agent (no ## Modes) -> {}", orchestrate.parse_agent_modes(legacy) == {})
 


### PR DESCRIPTION
## Summary
PR 3 of the Skill-First Phase 1 cycle (Epic #98): the first two agent-contract extractions. benchmark-librarian and knowledge-harvester now carry their operating contracts as `## Modes` sections in their own files; orchestrate.py invokes them via the composer (`run_agent(mode=..., params=...)`) with values-only params. All four legacy f-string prompts for these agents are deleted. This PR proves the extraction recipe the remaining eight tickets copy.

## Tickets
- Closes #105 — B1: Extract benchmark-librarian (first — proves the recipe)
- Closes #106 — B2: Extract knowledge-harvester (pipeline + backfill modes)

## Approach
Per the shared recipe (feature #100): diff `.md` vs injected prompts → resolve contradictions per Decision 4 (injected wins for pipeline, `.md` wins for standalone/backfill, per-phase where they differ) → write mode sections → switch orchestrate.py call sites → behavioral evidence via composed-vs-legacy prompt comparison (59–63 instruction checks per agent, zero lost instructions).

## CONTRADICTION LOG (Decision 4 — the reviewer-facing record)
**benchmark-librarian (6 resolutions):**
1. `.md`'s `benchmarks/` registry paths don't exist in the repo; injected prompt reads `knowledge/domains/{domain}/benchmarks.md`. Pipeline whitelist leads with the injected path; registry paths retained per ticket (skip-if-missing discipline covers absence). *Pre-existing broken reference, carried not created.*
2. **Journal/telemetry — resolved per-phase, not per-mode** (fixed in 43a1b82 after spec review caught the first attempt over-suppressing): non-interactive single-phase suppresses journal writes (production reality); interactive phases 1/2 follow the core Telemetry Protocol (also production reality). The initial uniform suppression would have been a silent behavior change in interactive runs — reverted.
3. Checkpoint delivery selector re-keyed from "PHASE DIRECTIVE present" to the mode contract (`checkpoint: file` vs `interactive`). Same behavior, new selector.
4. Phase Execution Protocol section moved from core into the pipeline mode block (content preserved).
5. `inputs.required` = the 3 discovery files the discovery step actually asserts; stakeholder_intelligence + intake are optional.
6. OUTPUT DISCIPLINE now applies in interactive P1/P2 too (legacy P1/P2 were silent) — discipline added, nothing lost.

**knowledge-harvester:** no true contradictions — the injected prompt matched the `.md`'s core rules verbatim. `backfill` mode authored fresh from the frontmatter description (`.md` wins for non-pipeline modes). Telemetry Protocol section added honestly (c7ef71d): pipeline mode keeps production behavior (no journal — audit trail is `.harvest_summary.txt` + registry row); backfill mode journals with a TELEMETRY block.

## Focus Areas
- Behavioral fidelity: the composed pipeline prompts vs the deleted f-strings (recover via `git show 541024c^:scripts/orchestrate.py` / `001ec5b^:...`). The eval harness scores artifacts, not live runs — this diff is the real behavioral review surface.
- The per-phase journal-suppression wording in benchmark-librarian's pipeline mode (43a1b82) — conditional prose, since the composer does values-only substitution and can't omit lines per phase.
- `_timed_agent` mode/params pass-through in orchestrate.py.

## Risk Flags
- [ ] Breaking changes: no — composed prompts verified instruction-complete against legacy
- [ ] Migration needed: no
- [x] Affects existing behavior: knowledge-harvester backfill mode now journals (new behavior for a previously frontmatter-only mode); benchmark-librarian interactive phases explicitly keep journaling (production behavior, now contractual)

## Skip List
- `tests/fixtures/mode_composer_selftest.py` — one-line legacy-example repoint (benchmark-librarian → workshop-preparation), necessitated by the extraction itself
- File growth over the ~20% budget (bench +21%, harvester +78%): reviewed and accepted — small files pay a fixed two-mode contract overhead; the budget was calibrated for large agents (which must shrink)

## CI Coverage
- test_agent.py 30/30 incl. all #103 mode checks (schema, required keys, exact mode sets)
- benchmark-librarian unit 1.000; pipeline altitude 1.000; gate BLOCKING post-#92

## Testing
- Composed-vs-legacy: 63 instruction checks (bench, all three phase values) + 6-step mapping (harvester) — zero lost instructions
- Per-ticket verify green after every commit
- NOT tested: live SDK invocation through the mode path (harness scores artifacts; first live proof will be the next real pipeline run — flagged for /bb-pr-review attention)

## Base-branch note
Stacked on `mariamt/20260724-skill-first-pr2` (PR #117). Review order: #92 → #116 → #117 → this.
