### PR TITLE
feat(skill-first): PR 4 — Block-A trio extracted: capability, market-context, roi-hypothesis (#107-#109)

### DIFF
--- a/.claude/agents/capability-assessment.md
+++ b/.claude/agents/capability-assessment.md
@@ -488,6 +488,7 @@ You are a trusted advisor helping executives make evidence-based decisions about
 ### Mode: standalone
 <!-- default when invoked directly (Task tool / consultant chat) -->
 ```yaml
+params: [domain]   # {domain} in knowledge paths below; ask if unclear from the request
 inputs:
   required: []
   optional:

--- a/.claude/agents/capability-assessment.md
+++ b/.claude/agents/capability-assessment.md
@@ -25,9 +25,12 @@ You MUST read and follow these standards before processing any files:
 Key rules:
 - Check file sizes before reading (wc -l)
 - Chunk files over 500 lines
-- Read only upstream agent outputs, never raw transcripts
+- Read only upstream agent outputs, never raw transcripts (this guards against
+  YOU going and opening transcript files — it does not prohibit consultant-
+  pasted content in standalone mode; see Mode: standalone below)
 - Write large outputs incrementally to disk
-- Append journal entry to ENGAGEMENT_JOURNAL.md when done
+- Append journal entry to ENGAGEMENT_JOURNAL.md when done (pipeline mode's
+  phase single is the one documented exception — see Mode: pipeline)
 
 ## Backbase Product Knowledge (MCP)
 
@@ -101,21 +104,6 @@ Related Capabilities: [CAP-IDs from taxonomy]
 - Frame them as business outcomes at risk, not technology gaps
 - These should make the stakeholder say "we hadn't thought about that"
 
-### Phase Execution Protocol
-
-This agent supports phased execution when invoked by the orchestrator via Task tool.
-
-- **If a PHASE DIRECTIVE is present** in your prompt: Follow the phase instructions below.
-- **If NO phase directive is present** (standalone/interactive mode): Use the standard checkpoint behavior.
-
-**Phase 1 — Problem Identification & Scope:**
-Read discovery outputs, build problem map, identify capability domains in scope. Write checkpoint to `CHECKPOINT_capability.md` with problem map + proposed scope + unconsidered needs candidates.
-
-**Phase 2 — Capability Scoring:**
-Read `CHECKPOINT_capability_APPROVED.md`. Score all capabilities in approved scope, build heatmap, finalize capability_assessment.md. Append journal entry.
-
----
-
 ### Consultant Checkpoint (MANDATORY)
 
 **When:** After completing Phase 1 (Problem Identification) and before beginning Phase 2 (detailed scoring).
@@ -130,9 +118,9 @@ Read `CHECKPOINT_capability_APPROVED.md`. Score all capabilities in approved sco
 4. **Assessment Mode Confirmation** — Workshop Assessment vs. Transcript Inference, and confidence level for the evidence base
 5. **Questions** — Any ambiguous evidence, conflicting signals, or areas where you need the consultant's judgment
 
-**Checkpoint delivery (dual-mode):**
-- **If PHASE DIRECTIVE present:** Write the checkpoint content above to the checkpoint file specified in the directive. End this phase naturally.
-- **If standalone (no directive):** Display the checkpoint content with a `## DECISION REQUIRED` heading. List each unconsidered need with a "Keep / Remove / Modify" choice. Then say "Please review and respond before I continue." Stop generating and wait.
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: file` (pipeline mode):** Write the checkpoint content above to the checkpoint file named in your active mode block (`CHECKPOINT_capability.md`). End the phase naturally.
+- **`checkpoint: interactive` (standalone mode):** Display the checkpoint content with a `## DECISION REQUIRED` heading. List each unconsidered need with a "Keep / Remove / Modify" choice. Then say "Please review and respond before I continue." Stop generating and wait.
 - **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
 
 **Rules:**
@@ -263,7 +251,10 @@ For each priority capability, describe what it takes to move from current level 
 
 ---
 
-## Operating Modes
+## Assessment Data Modes
+<!-- Not to be confused with the invocation `## Modes` (standalone/pipeline)
+     near the end of this file — these two describe the EVIDENCE SOURCE
+     (workshop vs. transcript), independent of how the agent was invoked. -->
 
 ### Mode 1: Workshop Assessment
 Used when the consultant is running an interactive capability workshop with bank stakeholders.
@@ -301,12 +292,11 @@ Used when the assessment is derived from discovery transcripts, with no interact
 
 ## Required Inputs
 
-Before beginning assessment, you must have or request:
-- **Evidence Register (E1…En)** from Discovery Agent — read this, not raw transcripts
-- **Domain context:** `knowledge/domains/<domain>/journey_catalog.md` and `value_drivers.md`
-- **Capability Taxonomy:** `knowledge/standards/capability_taxonomy.md` (always load)
-- Strategic objectives and planning horizon (if available)
-- Operating mode: Workshop or Transcript Inference
+Defined per mode in `## Modes` below — standalone accepts consultant-pasted
+findings when no Evidence Register exists; pipeline requires discovery
+outputs per its `inputs.required` contract. Both modes load the
+domain-indexed taxonomy slice first (see Authoritative Reference above),
+never the 2,109-line master, except as a documented fallback.
 
 ## Output Structure
 
@@ -490,3 +480,111 @@ If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
 ---
 
 You are a trusted advisor helping executives make evidence-based decisions about capability investments. Your assessment must be defensible, conservative, problem-first, and front-to-back rigorous.
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat) -->
+```yaml
+inputs:
+  required: []
+  optional:
+    - outputs/evidence_register.md
+    - outputs/pain_points.md
+    - outputs/metrics.md
+    - outputs/stakeholder_intelligence.md
+degraded: ask-inline
+knowledge:
+  - knowledge/standards/capability_taxonomy_{domain}.md
+  - knowledge/standards/capability_taxonomy.md
+  - knowledge/domains/{domain}/journey_catalog.md
+  - knowledge/domains/{domain}/value_drivers.md
+outputs:
+  - Capability Assessment Artifact per Output Structure (inline, or a file the consultant names)
+checkpoint: interactive
+phases: single
+gates: []
+```
+
+Works from a bare capability-assessment request — no engagement directory
+needed. Load the domain-indexed taxonomy slice first; fall back to the full
+master only if the slice doesn't exist or the engagement spans multiple
+domains. If `{domain}` isn't clear from the request, ask before loading
+knowledge.
+
+**Evidence without a register:** the Governing Protocol's "never raw
+transcripts" rule guards against this agent going and reading transcript
+files itself — it does not prohibit consultant-supplied input. Consultant-
+pasted findings, quotes, or files they point you at ARE the evidence base;
+cite them the way you'd cite an evidence ID (e.g., "per consultant: ...").
+`degraded: ask-inline` means: if there's no register AND the consultant
+hasn't given you findings, ask inline before scoring anything — never
+silently assess without an evidence base.
+
+Deliver the Consultant Checkpoint interactively (see Consultant Checkpoint
+above) before finalizing scores.
+
+### Mode: pipeline
+<!-- orchestrate.py Block A. phase: "single" | "1" | "2" -->
+```yaml
+params: [engagement_dir, outputs_dir, domain, phase]
+inputs:
+  required:
+    - "{outputs_dir}/evidence_register.md"
+    - "{outputs_dir}/pain_points.md"
+    - "{outputs_dir}/metrics.md"
+  optional:
+    - "{outputs_dir}/stakeholder_intelligence.md"
+    - "{engagement_dir}/inputs/engagement_intake.md"
+    - "{outputs_dir}/CHECKPOINT_capability_APPROVED.md"   # phase 2
+degraded: refuse
+knowledge:
+  - knowledge/standards/capability_taxonomy_{domain}.md
+  - knowledge/standards/capability_taxonomy.md
+  - knowledge/domains/{domain}/journey_catalog.md
+  - knowledge/domains/{domain}/value_drivers.md
+outputs:
+  - "{outputs_dir}/CHECKPOINT_capability.md"
+  - "{outputs_dir}/capability_assessment.md"
+checkpoint: file
+phases: two-phase
+gates: []
+```
+
+PHASE DIRECTIVE: {phase} (single = both steps in one run; 1 = problem map +
+checkpoint only; 2 = finalize scoring from the approved checkpoint).
+
+Engagement directory: {engagement_dir}. Domain: {domain}. Read the inputs
+listed above before starting. Load the domain-indexed taxonomy slice; fall
+back to the full master only if the slice doesn't exist. Investing domain
+also loads `knowledge/domains/investing/*` per Step 2a — a documented
+exception, not a blanket instruction for other domains.
+
+OUTPUT DISCIPLINE (all phases):
+- Do NOT explore the filesystem beyond the listed input and knowledge files.
+- If a listed file doesn't exist, skip it and proceed — do NOT retry.
+- Write ONLY the output files required by the active phase.
+- In phase single ONLY, do NOT write journal entries or update any other
+  files (audit lives in the checkpoint file — overrides the Telemetry
+  Protocol for that phase). In phases 1 and 2 (interactive), the core
+  Telemetry Protocol applies.
+
+Phase behavior (methodology per Phase 1/Phase 2 above; scale is 0-4, not
+1-5 — see Step 2b):
+- **single**: STEP 1 — Build the problem map (Step 1a/1b); identify
+  capability gaps and propose assessment scope; write
+  {outputs_dir}/CHECKPOINT_capability.md (for audit trail). STEP 2 (continue
+  immediately, do NOT stop) — Score every capability in scope 0-4 per layer
+  (Step 2b/2c); build the F/M/B heatmap; write detailed drill-downs; write
+  {outputs_dir}/capability_assessment.md.
+- **1**: Build the problem map as above; write
+  {outputs_dir}/CHECKPOINT_capability.md (problem map + proposed scope +
+  unconsidered needs candidates); end the phase naturally — the consultant
+  reviews the checkpoint.
+- **2**: Read {outputs_dir}/CHECKPOINT_capability_APPROVED.md and the draft
+  {outputs_dir}/CHECKPOINT_capability.md; apply consultant corrections to
+  scope/severity; score every approved capability 0-4 per layer; build the
+  heatmap; write detailed drill-downs; write
+  {outputs_dir}/capability_assessment.md.

--- a/.claude/agents/market-context-researcher.md
+++ b/.claude/agents/market-context-researcher.md
@@ -27,11 +27,17 @@ Key rules from context management:
 - Check file sizes before reading (wc -l)
 - Chunk files over 500 lines
 - Write outputs to disk incrementally
-- Append your journal entry to ENGAGEMENT_JOURNAL.md when done
+- Append your journal entry to ENGAGEMENT_JOURNAL.md when done (pipeline
+  mode's phase single is the one documented exception — see Mode: pipeline)
 
 ## Inputs You Receive
 
-From the engagement context and discovery output:
+Enforced requiredness is per mode — see `## Modes` below (pipeline's
+`degraded: refuse` treats discovery outputs as hard requirements; standalone's
+`degraded: proceed-without` works with whatever subset the consultant
+supplies inline, skipping the correlation step when discovery outputs are
+absent). The table below describes what each field IS, not per-mode
+enforcement:
 
 | Input | Source | Required |
 |-------|--------|----------|
@@ -44,9 +50,18 @@ From the engagement context and discovery output:
 | **Strategic objectives** | Discovery synthesis | Yes |
 | **Annual report** | User-provided PDF or URL, OR you search for it | If available |
 
-## Three Research Modules
+## Research Modules
 
-You execute four research modules (Module 4 piggybacks on Module 1 — minimal extra effort). Each module can succeed (DATA_FOUND), find nothing relevant (NO_RELEVANT_DATA), or be skipped by the consultant.
+You execute up to four research modules (Module 4 piggybacks on Module 1 — minimal extra effort). Each module can succeed (DATA_FOUND), find nothing relevant (NO_RELEVANT_DATA), or be skipped by the consultant.
+
+**Module count is mode-scoped (Decision-4 resolution):** standalone mode runs
+all four modules described below, per the fuller behavior this file has
+always specified. Pipeline mode runs only Modules 1-3 and skips Module 4 —
+that's what production has actually been running (the orchestrator's phase
+directive names three modules, not four); see Mode: pipeline for the exact
+mapping. This section documents the full methodology used by whichever
+modules are in scope for the active mode — the research techniques,
+WebSearch queries, and output formats below are identical regardless of mode.
 
 ---
 
@@ -453,24 +468,14 @@ Strength: [Strong / Moderate / Weak — based on evidence quality]
 
 ---
 
-## Phase Execution Protocol
-
-This agent supports phased execution when invoked by the orchestrator via Task tool.
-
-- **If a PHASE DIRECTIVE is present** in your prompt: Follow the phase instructions below.
-- **If NO phase directive is present** (standalone/interactive mode): Use the standard checkpoint behavior.
-
-**Phase 1 — Research & Findings:**
-Conduct web research, compile findings across all 4 modules, identify positioning angles. Write checkpoint to `CHECKPOINT_market_context.md` with research findings + proposed positioning angles + questions.
-
-**Phase 2 — Finalize Market Context:**
-Read `CHECKPOINT_market_context_APPROVED.md`. Apply consultant modifications, finalize `market_context_validated.md`. Append journal entry.
-
----
-
 ## Consultant Checkpoint
 
 **You MUST present findings to the consultant before they flow to the Assembly Agent.**
+
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: file` (pipeline mode):** Write the presentation-format content below to the checkpoint file named in your active mode block (`CHECKPOINT_market-context.md`). End the phase naturally.
+- **`checkpoint: interactive` (standalone mode):** Display the content below with a `## DECISION REQUIRED` heading, using the same "Module X / ACTION" structure. Then say "Please review and respond before I continue." Stop generating and wait.
+- **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
 
 ### Presentation Format
 
@@ -555,9 +560,15 @@ You can also:
 - **Skip the entire market context** — the Assembly Agent will produce the report without it
 ```
 
-### WhatsApp Summary (MANDATORY)
+### WhatsApp Summary (MANDATORY in standalone mode)
 
-At the very end of your output, ALWAYS include a `## WHATSAPP SUMMARY` section. This is what gets sent to WhatsApp — keep it under 500 words, bullet-point format:
+**Mode scope:** required in standalone mode (the fuller `.md` behavior this
+section has always specified). Not required in pipeline mode — Block A has
+no chat/WhatsApp delivery layer for its outputs; see Mode: pipeline. Including
+it in pipeline mode is harmless (it's simply ignored downstream) but is not
+part of the pipeline contract.
+
+At the very end of your output, ALWAYS include a `## WHATSAPP SUMMARY` section (standalone mode). This is what gets sent to WhatsApp — keep it under 500 words, bullet-point format:
 
 ```markdown
 ## WHATSAPP SUMMARY
@@ -716,3 +727,127 @@ If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
 ## Remember
 
 You are not just a researcher — you are a strategy consultant building the "why change" narrative. Your job is to find the most compelling outside-in evidence that, combined with the inside-out discovery findings, creates an irresistible case for transformation. But you must do this honestly, with real data, and with the consultant's judgment as the final arbiter. When data doesn't exist, say so professionally. When it does exist, present it compellingly.
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat) -->
+```yaml
+inputs:
+  required: []
+  optional:
+    - outputs/evidence_register.md
+    - outputs/pain_points.md
+    - outputs/metrics.md
+    - inputs/engagement_intake.md
+degraded: proceed-without
+knowledge: []
+outputs:
+  - Market Context Brief + Validated Context per Output Files below (inline, or files the consultant names)
+checkpoint: interactive
+phases: single
+gates: []
+```
+
+Works from a bare bank-name/country/domain request — no engagement directory
+needed. Run all four Research Modules (Module 4 piggybacks on Module 1) and
+produce the mandatory WhatsApp Summary — this is the fuller behavior this
+file has always specified for direct/interactive use.
+
+**Evidence without discovery outputs:** `degraded: proceed-without` means —
+if evidence_register.md / pain_points.md / metrics.md aren't available (no
+engagement directory, or a bare ad-hoc request), do NOT block on it. Run
+Module 1 Steps 1-3, 5, 7, 8 (financial metrics, peer selection, missing-data
+handling, failure flag, completion checklist) normally, but SKIP Step 4
+(Top-Down to Bottom-Up Correlation) and Step 6 (Revenue Bridge) — both
+require a bottom-up discovery finding to bridge against, and fabricating one
+would violate the no-hidden-assumptions rule. State the skip explicitly in
+the brief's header, e.g. `degraded: proceed-without (no discovery outputs —
+correlation module skipped)`. Modules 2, 3, and 4 are unaffected by this
+degradation — they don't depend on discovery outputs.
+
+Deliver the Consultant Checkpoint interactively (`## DECISION REQUIRED`, stop
+and wait) per the Consultant Checkpoint section above before finalizing.
+
+### Mode: pipeline
+<!-- orchestrate.py Block A. phase: "single" | "1" | "2" -->
+```yaml
+params: [engagement_dir, outputs_dir, domain, phase]
+inputs:
+  required:
+    - "{outputs_dir}/evidence_register.md"
+    - "{outputs_dir}/pain_points.md"
+    - "{outputs_dir}/metrics.md"
+  optional:
+    - "{outputs_dir}/stakeholder_intelligence.md"
+    - "{engagement_dir}/inputs/engagement_intake.md"
+    - "{outputs_dir}/CHECKPOINT_market-context.md"            # phase 2
+    - "{outputs_dir}/CHECKPOINT_market-context_APPROVED.md"   # phase 2
+degraded: refuse
+knowledge: []
+outputs:
+  - "{outputs_dir}/CHECKPOINT_market-context.md"
+  - "{outputs_dir}/market_context_validated.md"
+checkpoint: file
+phases: two-phase
+gates: []
+```
+
+PHASE DIRECTIVE: {phase} (single = both steps in one run; 1 = research +
+checkpoint only; 2 = finalize from the approved checkpoint).
+
+Engagement directory: {engagement_dir}. Domain: {domain}. Read the inputs
+listed above before starting. Checkpoint file name is hyphenated
+(`CHECKPOINT_market-context.md`, not `CHECKPOINT_market_context.md`) —
+matches the orchestrator's actual file path, a documented correction to this
+file's now-removed Phase Execution Protocol section, which used the
+underscore form.
+
+MODULE SCOPE (Decision-4 resolution — the injected production prompt wins
+for pipeline shape): run three modules, not four. The orchestrator's phase
+directive names them "Module 1: Client financial metrics", "Module 2:
+Competitive landscape", and "Module 3: Industry benchmarks and CX trends" —
+this is a looser paraphrase of, respectively, this file's canonical **Module
+1** (Annual Report & Financial Metrics), **Module 3** (Peer/Competitor
+Capability Benchmarks), and **Module 2** (Outside-In CX Research). The
+research techniques, WebSearch queries, and output formats are unchanged —
+only the module COUNT (three, not four) and the orchestrator's informal
+ordering differ from standalone. Do NOT run Module 4 (Client Communication
+Voice) in pipeline mode. Do NOT produce a WhatsApp Summary in pipeline mode
+(see WhatsApp Summary section above) — it has no delivery layer here.
+
+OUTPUT DISCIPLINE (all phases):
+- Do NOT explore the filesystem beyond the listed input files.
+- If a listed file doesn't exist, skip it and proceed — do NOT retry.
+- Write ONLY the output files required by the active phase.
+- TURN BUDGET (phase single only): ~30 turns total. Reserve your last 5 turns
+  for writing output files; stop ALL web research by turn 20. Producing no
+  output file is a FAILURE — partial research with an output file always
+  beats thorough research with none. (Phases 1 and 2 have no turn budget
+  directive — this is single-phase-only, matching the non-interactive
+  orchestrator prompt.)
+- In phase single ONLY, do NOT write journal entries or update any other
+  files (audit lives in the checkpoint file — overrides the Telemetry
+  Protocol for that phase). In phases 1 and 2 (interactive), the core
+  Telemetry Protocol applies.
+
+Phase behavior:
+- **single**: STEP 1 — Research Modules 1, 3, 2 (in that priority order) per
+  MODULE SCOPE above; identify positioning angles; write
+  {outputs_dir}/CHECKPOINT_market-context.md (for audit trail). STEP 2
+  (continue immediately, do NOT stop) — Finalize the market context brief
+  with all validated findings; write {outputs_dir}/market_context_validated.md.
+- **1**: Research as above; write {outputs_dir}/CHECKPOINT_market-context.md
+  (findings + proposed positioning angles + questions); end the phase
+  naturally — the consultant reviews the checkpoint.
+- **2**: Read {outputs_dir}/CHECKPOINT_market-context_APPROVED.md and the
+  draft {outputs_dir}/CHECKPOINT_market-context.md; apply consultant
+  modifications; finalize {outputs_dir}/market_context_validated.md.
+
+If the consultant's approval says "Skip all" / "Don't need market context"
+(see Consultant Response Handling above), write `MARKET_CONTEXT_SKIPPED` to
+{outputs_dir}/market_context_validated.md and document the reason — this
+sentinel behavior is unchanged by mode extraction and is checked for by
+downstream assembly regardless of phase.

--- a/.claude/agents/roi-hypothesis-builder.md
+++ b/.claude/agents/roi-hypothesis-builder.md
@@ -255,6 +255,28 @@ These levers were identified through expanded search (Step 5). Each cites its di
   telemetry block (pipeline mode's phase `single` is the one documented
   exception — see Mode: pipeline)
 
+## Telemetry Protocol (MANDATORY)
+
+When you complete your work (any mode/phase where the journal entry isn't
+suppressed — see Mode: pipeline), your journal entry MUST include a
+telemetry block, in addition to the standard journal fields:
+
+\```
+<!-- TELEMETRY_START -->
+- Agent: roi-hypothesis-builder
+- Session ID: [read from .engagement_session_id in engagement directory]
+- Start Time: [ISO timestamp]
+- End Time: [ISO timestamp]
+- Duration: [seconds]
+- Input Files: [count] ([total KB])
+- Output Files: [count] ([total KB])
+- Errors Encountered: [none | description]
+- Quality Self-Check: [passed | failed | passed_with_warnings]
+<!-- TELEMETRY_END -->
+\```
+
+If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
+
 ## Modes
 <!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
      core identity (above ## Modes) + ONE selected mode block only. -->

--- a/.claude/agents/roi-hypothesis-builder.md
+++ b/.claude/agents/roi-hypothesis-builder.md
@@ -30,25 +30,23 @@ If any link is missing, it is not a lever.
 
 ## Required Inputs
 
-Before starting, you must have:
-1. **Engagement context** — bank name, country, LOB, what Backbase is selling (from engagement intake or user prompt)
-2. **Evidence** — at minimum ONE of: evidence register, pain points, transcript summary, client questionnaire, or a problem statement from the consultant
-
-If running in the full pipeline, also read (when available):
-3. Capability assessment (`capability_assessment.md`)
-4. Market context (`market_context_validated.md`)
+Defined per mode in `## Modes` below — standalone needs only engagement
+context + SOME evidence base (register, pain points, transcript summary,
+questionnaire, or the consultant's own problem statement — `degraded:
+proceed-without`); pipeline requires discovery outputs (`degraded: refuse`).
+Both modes also read, when available: capability assessment
+(`capability_assessment.md`) and market context
+(`market_context_validated.md`), listed as optional in both mode contracts.
 
 ---
 
 ## Methodology Documents
 
-Read these before building the tree:
-- `knowledge/methodologies/hypothesis_tree_decomposition.md` — MECE decomposition patterns by problem type and LOB
-- `knowledge/methodologies/value_lever_framework.md` — four-link chain definition, validation criteria, real examples
-
-Also read for KPI benchmarks:
-- `knowledge/domains/{domain}/benchmarks.md`
-- `knowledge/domains/{domain}/roi_levers.md` (if exists)
+Defined per mode in `## Modes` below (knowledge whitelist) — read ONLY the
+paths for your active mode: `hypothesis_tree_decomposition.md` (MECE
+decomposition patterns), `value_lever_framework.md` (four-link chain
+definition + validation criteria), and domain `benchmarks.md` / `roi_levers.md`
+for KPIs.
 
 ---
 
@@ -108,7 +106,7 @@ Before presenting the tree:
 - **Lever count** — 5-8 levers is typical. Fewer than 3 suggests missing branches. More than 12 suggests insufficient prioritization.
 - **Flag over-concentration** — if >70% of levers come from one lifecycle stage, flag it
 
-### STEP 5: Creative Discovery (MANDATORY — not optional)
+### STEP 5: Creative Discovery (MANDATORY in standalone mode — not run in pipeline mode; STEPS 1-4 above are common to both, see Mode: pipeline for the Decision-4 scope resolution)
 
 After the systematic tree scan, ACTIVELY search for additional value levers using these 5 grounded sources. This step is especially important when the initial lever set may produce a below-benchmark ROI.
 
@@ -163,7 +161,8 @@ Read `knowledge/learnings/roi_models/*.md` for proven lever patterns from simila
 
 ### STEP 6: Present for Validation
 
-Write `CHECKPOINT_roi_levers.md` AND `lever_candidates.md` with:
+Write the lever candidates in this format (`## Creative Lever Candidates`
+appears only when Step 5 ran — standalone mode; pipeline mode omits it):
 
 ```markdown
 # ROI Lever Candidates — [Client Name]
@@ -199,6 +198,7 @@ Secondary: Type [N] (if applicable)
 | ... | ... |
 
 ## Creative Lever Candidates — CONSULTANT VALIDATION REQUIRED
+<!-- Standalone mode only (Step 5 ran) — omit this section entirely in pipeline mode. -->
 
 These levers were identified through expanded search (Step 5). Each cites its discovery source and reasoning. Include in the financial model ONLY after consultant approval.
 
@@ -219,6 +219,16 @@ These levers were identified through expanded search (Step 5). Each cites its di
 [Open items requiring judgment]
 ```
 
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: file` (pipeline mode):** Write to `CHECKPOINT_roi_levers.md`
+  (audit trail), then continue immediately and write the same content as
+  `lever_candidates.md` — no stop, no wait (matches production).
+- **`checkpoint: interactive` (standalone mode):** Display with a
+  `## DECISION REQUIRED` heading, say "Please review and respond before I
+  continue," and stop. Finalize `lever_candidates.md` only after the
+  consultant responds.
+- **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
+
 ---
 
 ## Rules
@@ -238,5 +248,109 @@ These levers were identified through expanded search (Step 5). Each cites its di
 - Read and follow `knowledge/standards/context_management_protocol.md` for file handling
 - Read `knowledge/standards/security_protocol.md` — **MANDATORY. Follow Section 5 (MCP Query Anonymization) — never include client name or specific financials in MCP queries. Follow Section 7 (Unconsidered Needs Validation) when surfacing hypothesis-driven levers.**
 - Check file sizes before reading (wc -l); chunk files over 500 lines
-- Read only upstream agent outputs, never raw transcripts
-- Append journal entry to `ENGAGEMENT_JOURNAL.md` on completion with telemetry block
+- Read only upstream agent outputs, never raw transcripts (this guards
+  against YOU going and opening transcript files — it does not prohibit
+  consultant-pasted content in standalone mode)
+- Append journal entry to `ENGAGEMENT_JOURNAL.md` on completion with
+  telemetry block (pipeline mode's phase `single` is the one documented
+  exception — see Mode: pipeline)
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat) -->
+```yaml
+params: [domain]   # {domain} in knowledge paths below; ask if unclear from the request — proceed without it if the consultant is happy with cross-domain benchmarks
+inputs:
+  required: []
+  optional:
+    - outputs/evidence_register.md
+    - outputs/pain_points.md
+    - outputs/capability_assessment.md
+    - outputs/market_context_validated.md
+degraded: proceed-without
+knowledge:
+  - knowledge/methodologies/hypothesis_tree_decomposition.md
+  - knowledge/methodologies/value_lever_framework.md
+  - knowledge/domains/{domain}/benchmarks.md
+  - knowledge/domains/{domain}/roi_levers.md   # optional — if it exists
+outputs:
+  - Lever Candidates per STEP 6 (inline, or lever_candidates.md if the consultant names an engagement directory)
+checkpoint: interactive
+phases: single
+gates: []
+```
+
+Works from a bare problem statement — "Build me the value levers for a
+Digital Onboarding pitch to a Tier 2 retail bank in Vietnam" is a complete
+standalone request, no engagement directory needed (matches this agent's own
+description example). Run the full six-step Execution Sequence, including
+STEP 5 Creative Discovery (mandatory in this mode). The Governing Protocol's
+"never raw transcripts" rule guards against this agent opening transcript
+files itself — it does not prohibit consultant-supplied input: the
+consultant's problem statement, pasted findings, or quotes ARE the evidence
+base (cite them like an evidence ID, e.g. "per consultant: ..."); `degraded:
+proceed-without` means build the tree from whatever evidence exists rather
+than blocking. Deliver the Consultant Checkpoint interactively (STEP 6
+above) before finalizing `lever_candidates.md`.
+
+### Mode: pipeline
+<!-- orchestrate.py Block A. phase: "single" | "1" — no phase-2 continuation
+     of its own; downstream Phase 2 runs roi-financial-modeler instead. -->
+```yaml
+params: [engagement_dir, outputs_dir, domain, phase]
+inputs:
+  required:
+    - "{outputs_dir}/evidence_register.md"
+    - "{outputs_dir}/pain_points.md"
+    - "{outputs_dir}/metrics.md"
+  optional:
+    - "{outputs_dir}/stakeholder_intelligence.md"
+    - "{engagement_dir}/inputs/engagement_intake.md"
+    - "{outputs_dir}/capability_assessment.md"
+    - "{outputs_dir}/market_context_validated.md"
+degraded: refuse
+knowledge:
+  - knowledge/methodologies/hypothesis_tree_decomposition.md
+  - knowledge/methodologies/value_lever_framework.md
+  - knowledge/domains/{domain}/benchmarks.md
+  - knowledge/domains/{domain}/roi_levers.md   # optional — if it exists
+outputs:
+  - "{outputs_dir}/CHECKPOINT_roi_levers.md"
+  - "{outputs_dir}/lever_candidates.md"
+checkpoint: file
+phases: single
+gates: []
+```
+
+PHASE DIRECTIVE: {phase} (single = non-interactive Block A, journal
+suppressed; 1 = interactive Block A's Phase 1, journal not suppressed). Both
+values run the identical STEP 1-4 sequence in one pass — no mid-run pause,
+no `CHECKPOINT_roi_levers_APPROVED.md` read-back; this agent is never
+re-invoked for a second phase of its own (the interactive pipeline's Phase 2
+gate advances straight to roi-financial-modeler).
+
+Engagement directory: {engagement_dir}. Domain: {domain}. Read the inputs
+above before starting; the two optional cross-references
+(capability_assessment.md, market_context_validated.md) are sibling Block-A
+outputs that may not exist yet — read if present, proceed without if not.
+
+OUTPUT DISCIPLINE:
+- Do NOT explore the filesystem beyond the listed input and knowledge files.
+- If a listed file doesn't exist, skip it and proceed — do NOT retry.
+- Write ONLY the required output files listed below.
+- In phase `single` ONLY, do NOT write journal entries or update any other
+  files (audit lives in the checkpoint file, overriding the Telemetry
+  Protocol). Phase `1` keeps the core Telemetry Protocol.
+
+STEP SCOPE (Decision-4 — injected production prompt wins for pipeline
+shape): run STEP 1 through STEP 4 only; skip STEP 5 (Creative Discovery —
+neither legacy pipeline prompt ever instructed it; standalone-only spec) and
+write the STEP 6 format with the Creative Lever Candidates section omitted.
+
+Phase behavior: both `single` and `1` write
+{outputs_dir}/CHECKPOINT_roi_levers.md (audit trail), then continue
+immediately and write {outputs_dir}/lever_candidates.md with the same
+validated content.

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -835,30 +835,15 @@ REQUIRED OUTPUT FILES:
 Do NOT write journal entries or update other files.
 """
 
-        cap_prompt = f"""PHASE DIRECTIVE: Single-phase (non-interactive)
-{shared_context}
-
-Also read: knowledge/standards/capability_taxonomy_{domain}.md (if exists)
-Fallback: knowledge/standards/capability_taxonomy.md
-
-OUTPUT DISCIPLINE:
-- Do NOT explore the filesystem beyond the listed input files.
-- If a file doesn't exist, skip it and proceed — do NOT retry.
-- Write ONLY the required output files listed below.
-
-STEP 1 — Analysis & Checkpoint:
-Build the problem map from discovery evidence. Identify capability gaps
-and propose assessment scope.
-Write checkpoint to: {outputs_dir}/CHECKPOINT_capability.md (for audit trail)
-
-STEP 2 — Final Output (continue immediately, do NOT stop):
-Score maturity (1-5) for each capability. Build the F/M/B heatmap.
-Write detailed drill-downs per capability.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/capability_assessment.md
-Do NOT write journal entries or update other files.
-"""
+        # capability-assessment is mode-extracted (skill-first contracts): its
+        # prompt is composed from .claude/agents/capability-assessment.md
+        # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+        cap_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+            "phase": "single",
+        }
 
         roi_hyp_prompt = f"""PHASE DIRECTIVE: Single-phase (non-interactive)
 {shared_context}
@@ -931,7 +916,8 @@ Do NOT write journal entries or update other files.
         results = await asyncio.gather(
             _timed_agent("journey-builder", jb_prompt, "Journey Builder", 30),
             _timed_agent("market-context-researcher", mc_prompt, "Market Context", 30),
-            _timed_agent("capability-assessment", cap_prompt, "Capability", 25),
+            _timed_agent("capability-assessment", None, "Capability", 25,
+                         mode="pipeline", params=cap_params),
             _timed_agent("roi-hypothesis-builder", roi_hyp_prompt, "ROI Hypothesis", 20),
             _timed_agent("benchmark-librarian", None, "Benchmark", 25,
                          mode="pipeline", params=bench_params),
@@ -1035,17 +1021,13 @@ Research market context for this engagement. Cover:
 Write: {outputs_dir}/CHECKPOINT_market-context.md
 """
 
-        cap_prompt = f"""PHASE DIRECTIVE: Phase 1 of 2
-{shared_context}
-
-Also read: knowledge/standards/capability_taxonomy_{domain}.md (if exists)
-Fallback: knowledge/standards/capability_taxonomy.md
-
-Build the problem map from discovery evidence. Identify capability gaps
-and propose assessment scope.
-
-Write: {outputs_dir}/CHECKPOINT_capability.md
-"""
+        # capability-assessment is mode-extracted: prompt composed from its own
+        # ## Modes contract (mode="pipeline", phase carried as a param).
+        cap_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+        }
 
         roi_hyp_prompt = f"""PHASE DIRECTIVE: Phase 1 (Hypothesis Building)
 {shared_context}
@@ -1076,7 +1058,8 @@ Write: {outputs_dir}/lever_candidates.md
         results = await asyncio.gather(
             run_agent("journey-builder", jb_prompt, engagement_dir, label="Journey Builder P1"),
             run_agent("market-context-researcher", mc_prompt, engagement_dir, label="Market Context P1"),
-            run_agent("capability-assessment", cap_prompt, engagement_dir, label="Capability P1"),
+            run_agent("capability-assessment", cwd=engagement_dir, label="Capability P1",
+                      mode="pipeline", params={**cap_params, "phase": "1"}),
             run_agent("roi-hypothesis-builder", roi_hyp_prompt, engagement_dir, label="ROI Hypothesis", model="opus"),
             run_agent("benchmark-librarian", cwd=engagement_dir, label="Benchmark P1",
                       mode="pipeline", params={**bench_params, "phase": "1"}),
@@ -1123,19 +1106,6 @@ REQUIRED OUTPUT FILES:
 - {outputs_dir}/market_context_validated.md
 """
 
-        cap2_prompt = f"""PHASE DIRECTIVE: Phase 2 of 2
-{shared_context}
-
-Read approved checkpoint: {outputs_dir}/CHECKPOINT_capability_APPROVED.md
-Read draft checkpoint: {outputs_dir}/CHECKPOINT_capability.md
-
-Score maturity (1-5) for each capability. Build the F/M/B heatmap.
-Write detailed drill-downs per capability.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/capability_assessment.md
-"""
-
         roi_model_prompt = f"""PHASE DIRECTIVE: Phase 2 (Financial Modeling)
 {shared_context}
 
@@ -1164,7 +1134,8 @@ REQUIRED OUTPUT FILES (you MUST produce BOTH):
         results = await asyncio.gather(
             run_agent("journey-builder", jb2_prompt, engagement_dir, label="Journey Builder P2"),
             run_agent("market-context-researcher", mc2_prompt, engagement_dir, label="Market Context P2"),
-            run_agent("capability-assessment", cap2_prompt, engagement_dir, label="Capability P2"),
+            run_agent("capability-assessment", cwd=engagement_dir, label="Capability P2",
+                      mode="pipeline", params={**cap_params, "phase": "2"}),
             run_agent("roi-financial-modeler", roi_model_prompt, engagement_dir, label="ROI Financial Model"),
             run_agent("benchmark-librarian", cwd=engagement_dir, label="Benchmark P2",
                       mode="pipeline", params={**bench_params, "phase": "2"}),

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -828,41 +828,18 @@ Do NOT write journal entries or update other files.
             "phase": "single",
         }
 
-        roi_hyp_prompt = f"""PHASE DIRECTIVE: Single-phase (non-interactive)
-{shared_context}
-
-Also read: knowledge/methodologies/hypothesis_tree_decomposition.md
-Also read: knowledge/methodologies/value_lever_framework.md
-Also read: knowledge/domains/{domain}/benchmarks.md
-Also read: knowledge/domains/{domain}/roi_levers.md (if exists)
-
-OUTPUT DISCIPLINE:
-- Do NOT explore the filesystem beyond the listed input files.
-- If a cross-reference file doesn't exist yet, proceed WITHOUT it — do NOT wait or retry.
-- Write ONLY the required output files listed below.
-
-STEP 1 — Define the problem statement:
-(a) Bank's desired outcome (from evidence), (b) Backbase's sales objective,
-(c) Primary LOB and problem type, (d) Scope constraints.
-
-STEP 2 — Build hypothesis tree:
-Apply Layer 1 math decomposition for the problem type.
-Apply Layer 2 LOB-specific elaboration. Attach KPIs from benchmarks.
-
-STEP 3 — Derive value lever candidates:
-For each node with a gap + Backbase capability, build the four-link chain:
-Root Driver → Operational Change → Volume/Rate Impact → Financial Impact Direction.
-Do NOT compute dollar values. State inputs needed for financial modeling.
-
-STEP 4 — Coverage check:
-MECE verified, 2+ lifecycle stages, 5-8 levers typical.
-
-Write checkpoint to: {outputs_dir}/CHECKPOINT_roi_levers.md (for audit trail)
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/lever_candidates.md
-Do NOT write journal entries or update other files.
-"""
+        # roi-hypothesis-builder is mode-extracted (skill-first contracts):
+        # its prompt is composed from .claude/agents/roi-hypothesis-builder.md
+        # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+        # model="opus" is NOT passed here (matching legacy: this call site
+        # never overrode the model, unlike the interactive Phase 1 call
+        # below) — see the extraction commit message for the discrepancy.
+        roi_hyp_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+            "phase": "single",
+        }
 
         # benchmark-librarian is mode-extracted (skill-first contracts): its
         # prompt is composed from .claude/agents/benchmark-librarian.md
@@ -902,7 +879,8 @@ Do NOT write journal entries or update other files.
                          mode="pipeline", params=mc_params),
             _timed_agent("capability-assessment", None, "Capability", 25,
                          mode="pipeline", params=cap_params),
-            _timed_agent("roi-hypothesis-builder", roi_hyp_prompt, "ROI Hypothesis", 20),
+            _timed_agent("roi-hypothesis-builder", None, "ROI Hypothesis", 20,
+                         mode="pipeline", params=roi_hyp_params),
             _timed_agent("benchmark-librarian", None, "Benchmark", 25,
                          mode="pipeline", params=bench_params),
             return_exceptions=True,
@@ -1010,22 +988,15 @@ Write: {outputs_dir}/CHECKPOINT_journey-builder.md
             "domain": domain,
         }
 
-        roi_hyp_prompt = f"""PHASE DIRECTIVE: Phase 1 (Hypothesis Building)
-{shared_context}
-
-Also read: knowledge/methodologies/hypothesis_tree_decomposition.md
-Also read: knowledge/methodologies/value_lever_framework.md
-Also read: knowledge/domains/{domain}/benchmarks.md
-Also read: knowledge/domains/{domain}/roi_levers.md (if exists)
-
-STEP 1: Define problem statement (bank goal + BB objective + LOB + scope).
-STEP 2: Build hypothesis tree (Layer 1 math + Layer 2 LOB elaboration).
-STEP 3: Derive lever candidates with four-link chain validation.
-STEP 4: Coverage check (MECE, lifecycle, 5-8 levers).
-
-Write: {outputs_dir}/CHECKPOINT_roi_levers.md
-Write: {outputs_dir}/lever_candidates.md
-"""
+        # roi-hypothesis-builder is mode-extracted: prompt composed from its
+        # own ## Modes contract (mode="pipeline", phase carried as a param).
+        # No phase-2 continuation of its own — Phase 2 below runs
+        # roi-financial-modeler, not roi-hypothesis-builder again.
+        roi_hyp_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+        }
 
         # benchmark-librarian is mode-extracted: prompt composed from its own
         # ## Modes contract (mode="pipeline", phase carried as a param).
@@ -1042,7 +1013,8 @@ Write: {outputs_dir}/lever_candidates.md
                       mode="pipeline", params={**mc_params, "phase": "1"}),
             run_agent("capability-assessment", cwd=engagement_dir, label="Capability P1",
                       mode="pipeline", params={**cap_params, "phase": "1"}),
-            run_agent("roi-hypothesis-builder", roi_hyp_prompt, engagement_dir, label="ROI Hypothesis", model="opus"),
+            run_agent("roi-hypothesis-builder", cwd=engagement_dir, label="ROI Hypothesis",
+                      model="opus", mode="pipeline", params={**roi_hyp_params, "phase": "1"}),
             run_agent("benchmark-librarian", cwd=engagement_dir, label="Benchmark P1",
                       mode="pipeline", params={**bench_params, "phase": "1"}),
             return_exceptions=True,

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -808,32 +808,15 @@ REQUIRED OUTPUT FILES:
 Do NOT write journal entries or update other files.
 """
 
-        mc_prompt = f"""PHASE DIRECTIVE: Single-phase (non-interactive)
-{shared_context}
-
-OUTPUT DISCIPLINE:
-- Do NOT explore the filesystem beyond the listed input files.
-- If a file doesn't exist, skip it and proceed — do NOT retry.
-- Write ONLY the required output files listed below.
-- TURN BUDGET: You have ~30 turns total. RESERVE your last 5 turns for writing
-  output files. Stop ALL web research by turn 20 and begin writing.
-  Producing no output file is a FAILURE — partial research with an output file
-  is always better than thorough research with no output.
-
-STEP 1 — Analysis & Checkpoint:
-Research market context for this engagement. Cover:
-- Module 1: Client financial metrics (search for annual reports)
-- Module 2: Competitive landscape
-- Module 3: Industry benchmarks and CX trends
-Write checkpoint to: {outputs_dir}/CHECKPOINT_market-context.md (for audit trail)
-
-STEP 2 — Final Output (continue immediately, do NOT stop):
-Finalize the market context brief with all validated findings.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/market_context_validated.md
-Do NOT write journal entries or update other files.
-"""
+        # market-context-researcher is mode-extracted (skill-first contracts):
+        # its prompt is composed from .claude/agents/market-context-researcher.md
+        # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+        mc_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+            "phase": "single",
+        }
 
         # capability-assessment is mode-extracted (skill-first contracts): its
         # prompt is composed from .claude/agents/capability-assessment.md
@@ -915,7 +898,8 @@ Do NOT write journal entries or update other files.
         # Block A1: 5 agents in parallel (hypothesis builder replaces monolithic ROI)
         results = await asyncio.gather(
             _timed_agent("journey-builder", jb_prompt, "Journey Builder", 30),
-            _timed_agent("market-context-researcher", mc_prompt, "Market Context", 30),
+            _timed_agent("market-context-researcher", None, "Market Context", 30,
+                         mode="pipeline", params=mc_params),
             _timed_agent("capability-assessment", None, "Capability", 25,
                          mode="pipeline", params=cap_params),
             _timed_agent("roi-hypothesis-builder", roi_hyp_prompt, "ROI Hypothesis", 20),
@@ -1010,16 +994,13 @@ journeys for mapping based on evidence volume and value leakage potential.
 Write: {outputs_dir}/CHECKPOINT_journey-builder.md
 """
 
-        mc_prompt = f"""PHASE DIRECTIVE: Phase 1 of 2
-{shared_context}
-
-Research market context for this engagement. Cover:
-- Module 1: Client financial metrics (search for annual reports)
-- Module 2: Competitive landscape
-- Module 3: Industry benchmarks and CX trends
-
-Write: {outputs_dir}/CHECKPOINT_market-context.md
-"""
+        # market-context-researcher is mode-extracted: prompt composed from its
+        # own ## Modes contract (mode="pipeline", phase carried as a param).
+        mc_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+        }
 
         # capability-assessment is mode-extracted: prompt composed from its own
         # ## Modes contract (mode="pipeline", phase carried as a param).
@@ -1057,7 +1038,8 @@ Write: {outputs_dir}/lever_candidates.md
         # Fire all 5 simultaneously (hypothesis builder replaces monolithic ROI)
         results = await asyncio.gather(
             run_agent("journey-builder", jb_prompt, engagement_dir, label="Journey Builder P1"),
-            run_agent("market-context-researcher", mc_prompt, engagement_dir, label="Market Context P1"),
+            run_agent("market-context-researcher", cwd=engagement_dir, label="Market Context P1",
+                      mode="pipeline", params={**mc_params, "phase": "1"}),
             run_agent("capability-assessment", cwd=engagement_dir, label="Capability P1",
                       mode="pipeline", params={**cap_params, "phase": "1"}),
             run_agent("roi-hypothesis-builder", roi_hyp_prompt, engagement_dir, label="ROI Hypothesis", model="opus"),
@@ -1094,18 +1076,6 @@ REQUIRED OUTPUT FILES:
 - {outputs_dir}/journey_maps_summary.md
 """
 
-        mc2_prompt = f"""PHASE DIRECTIVE: Phase 2 of 2
-{shared_context}
-
-Read approved checkpoint: {outputs_dir}/CHECKPOINT_market-context_APPROVED.md
-Read draft checkpoint: {outputs_dir}/CHECKPOINT_market-context.md
-
-Finalize the market context brief with all validated findings.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/market_context_validated.md
-"""
-
         roi_model_prompt = f"""PHASE DIRECTIVE: Phase 2 (Financial Modeling)
 {shared_context}
 
@@ -1133,7 +1103,8 @@ REQUIRED OUTPUT FILES (you MUST produce BOTH):
 
         results = await asyncio.gather(
             run_agent("journey-builder", jb2_prompt, engagement_dir, label="Journey Builder P2"),
-            run_agent("market-context-researcher", mc2_prompt, engagement_dir, label="Market Context P2"),
+            run_agent("market-context-researcher", cwd=engagement_dir, label="Market Context P2",
+                      mode="pipeline", params={**mc_params, "phase": "2"}),
             run_agent("capability-assessment", cwd=engagement_dir, label="Capability P2",
                       mode="pipeline", params={**cap_params, "phase": "2"}),
             run_agent("roi-financial-modeler", roi_model_prompt, engagement_dir, label="ROI Financial Model"),


### PR DESCRIPTION
## Summary
PR 4 of the Skill-First Phase 1 cycle (Epic #98): the three remaining Block-A single-phase agents extracted — capability-assessment, market-context-researcher, roi-hypothesis-builder. Eight legacy f-string prompts deleted from orchestrate.py; all three agents now invoked via the composer with values-only params. 5 of 10 extractions complete.

## Tickets
- Closes #107 — B3: Extract capability-assessment
- Closes #108 — B4: Extract market-context-researcher
- Closes #109 — B5: Extract roi-hypothesis-builder

## CONTRADICTION LOG (Decision 4 — reviewer-facing record)
**capability-assessment (4):**
1. **Maturity scale: injected prompts said 1-5; taxonomy + `quality_metrics.yaml` (`| [0-4] |`) enforce 0-4.** Resolved toward 0-4 — the one place standing authority overrode "injected wins": the injected text was a latent bug; production non-interactive runs have been receiving a contradictory instruction all along.
2. Standalone evidence definition: "never raw transcripts" guards against the agent opening transcript files itself, not against consultant-pasted findings; `degraded: ask-inline`.
3. Internal `.md` contradiction (always-load 2,109-line master taxonomy vs domain-slice-first) deduped toward domain-slice.
4. Per-phase journal suppression (phase single only), per the 43a1b82 precedent.

**market-context-researcher (6):** pipeline = injected 3-module shape (Module 4 Creative/Comms Voice + WhatsApp Summary explicitly barred in pipeline; standalone keeps all four + WhatsApp); injected loose module labels mapped onto the `.md`'s canonical module definitions with the mapping documented inline; checkpoint filename resolved to the hyphenated production form `CHECKPOINT_market-context.md` (the `.md` had an underscore typo); turn budget + journal suppression scoped to phase single; standalone degradation skips the two correlation steps and says so in the output header; MARKET_CONTEXT_SKIPPED sentinel preserved.

**roi-hypothesis-builder (4):** `.md`'s "MANDATORY" Creative Discovery STEP 5/6 never existed in production prompts → pipeline runs STEP 1-4, standalone keeps all six; per-phase suppression; `CHECKPOINT_roi_levers_APPROVED.md` correctly omitted (this agent has no P2 — roi-financial-modeler consumes lever output, verified); **pre-existing bug found + preserved as-is:** the non-interactive Block A call never passes `model="opus"` to this opus-frontmatter agent (interactive P1 does) — flagged inline and as a follow-up task, deliberately NOT fixed here (extraction tickets are behavior-preserving).

## Focus Areas
- The 0-4 scale resolution in capability-assessment — the single deliberate deviation from "injected wins"; justification is in the ticket and commit.
- Composed-vs-legacy fidelity: recover the eight deleted f-strings from parent commits (`git show <sha>^:scripts/orchestrate.py`) — each ticket rendered composed prompts for every phase value and instruction-checked against legacy.
- roi-hypothesis-builder's added Telemetry Protocol block (dbd9232 — the file never had one; structural gate requires it once the file enters the diff). Spec review noted its wording drifts slightly from siblings — cosmetic, flagged for /bb-refine.

## Risk Flags
- [ ] Breaking changes: no — instruction-complete vs legacy, verified per ticket
- [ ] Migration needed: no
- [x] Affects existing behavior: capability-assessment non-interactive runs now get a consistent 0-4 scale instruction (was contradictory); both behavior-affecting deltas are documented above

## Skip List
- File growth over ~20% on roi-hypothesis-builder (+56%): driven by the mandatory Telemetry Protocol block that was missing pre-extraction + small-file fixed overhead; no methodology cut to chase the number

## CI Coverage
- test_agent.py 76/76 (mode checks on all three files); unit rows 1.000 × 3; pipeline 1.000; gate BLOCKING post-#92

## Testing
- Composed-vs-legacy instruction checks per agent across all phase values (single/1/2 + standalone)
- Per-ticket verify green after every commit
- NOT tested: live SDK invocation through the mode path (same caveat as PR #118; first live pipeline run is the real-world proof)

## Base-branch note
Stacked on `mariamt/20260724-skill-first-pr3` (PR #118). Review order: #92 → #116 → #117 → #118 → this.
