### PR TITLE
feat(skill-first): PR 5 — journey-builder + roadmap-prioritization extracted (#110, #111)

### DIFF
--- a/.claude/agents/journey-builder.md
+++ b/.claude/agents/journey-builder.md
@@ -30,22 +30,26 @@ You MUST read and follow these standards:
 
 ## Input Contract
 
-You read ONLY processed outputs from upstream agents. **Never read raw transcripts.**
+You read ONLY processed outputs from upstream agents. **Never read raw
+transcripts.** This guards against YOU going and opening transcript files
+yourself — it does not prohibit consultant-supplied input in standalone
+mode; see Mode: standalone below (same interpretation as
+capability-assessment's 2afba5d).
 
-**Required inputs (from engagement outputs directory):**
-- `evidence_register.md` — Factual claims with Evidence IDs, lifecycle stages, journey steps
-- `pain_points.md` or pain point register — Business problems mapped to lifecycle/journey
-- `metrics.md` or metric register — Quantitative data points with units
+Exact required/optional files per invocation are defined per mode in
+`## Modes` below — standalone accepts consultant-pasted evidence when no
+Evidence Register exists (`degraded: ask-inline`); pipeline requires the
+discovery triplet (evidence register, pain points, metrics) per its
+`inputs.required` contract (`degraded: refuse`).
 
 **Context inputs (from engagement):**
 - `ENGAGEMENT_JOURNAL.md` — Engagement metadata (domain, region, client name)
 - `.engagement_session_id` — Session UUID for telemetry
 - Engagement intake — Domain, region, benchmark confidence mode
 
-**Domain knowledge (from knowledge base):**
-- `knowledge/domains/<domain>/journey_maps.md` — Template journeys with standard phases
-- `knowledge/domains/<domain>/personas.md` — Domain personas
-- `knowledge/domains/<domain>/pain_points.md` — Known pain patterns
+**Domain knowledge (from knowledge base):** see the `knowledge` whitelist in
+each mode block below (`journey_maps.md`, `personas.md`, `pain_points.md`,
+domain-indexed).
 
 ## Output Contract
 
@@ -61,6 +65,8 @@ The JSON file contains:
 - `journeys[]` array (Layer 2 — individual per-journey swimlanes)
 
 Both files follow the schema defined in `templates/outputs/journey_maps.md`. Read that template before producing any output.
+
+**This schema is a FROZEN cross-skill contract.** `/generate-assessment-html` and the Assembly Agent (Act 4) both depend on it exactly as documented. Schema changes are out of scope for this ticket and this extraction cycle — see both mode blocks in `## Modes` below.
 
 ## Methodology
 
@@ -128,18 +134,6 @@ Write the "From X to Y" transformation narrative that threads through all stages
 
 ---
 
-## Phase Execution Protocol
-
-This agent executes in **3 phases** with two consultant checkpoints.
-
-| Phase | Action | Reads | Writes |
-|-------|--------|-------|--------|
-| **Phase 1** | Read discovery outputs, build journey experience map (Phase 0), identify journey candidates. | Evidence register, pain points, metrics, domain journey templates | `CHECKPOINT_journey_CP1.md` with journey candidates for consultant to select which to map |
-| **Phase 2** | Read approved CP1. Build swimlanes for selected journeys, estimate value leakage. | `CHECKPOINT_journey_CP1_APPROVED.md` | `CHECKPOINT_journey_CP2.md` with draft swimlanes + value estimates for validation |
-| **Phase 3** | Read approved CP2. Finalize deliverables. | `CHECKPOINT_journey_CP2_APPROVED.md` | `journey_maps.json` + `journey_maps_summary.md` (final deliverables) |
-
-**Phase transitions:** Phase 1 ends at CP1. Phase 2 begins after `CHECKPOINT_journey_CP1_APPROVED.md` is available. Phase 2 ends at CP2. Phase 3 begins after `CHECKPOINT_journey_CP2_APPROVED.md` is available.
-
 ### Phase 1: Journey Selection (Checkpoint #1)
 
 **Before building individual per-journey swimlanes, present the consultant with journey options.**
@@ -157,9 +151,9 @@ This agent executes in **3 phases** with two consultant checkpoints.
 
 This is a MANDATORY consultant checkpoint. If you skip it, the engagement is invalid. This is NON-NEGOTIABLE.
 
-**Checkpoint delivery (dual-mode):**
-- **If PHASE DIRECTIVE present:** Write the checkpoint content above to the checkpoint file specified in the directive. End this phase naturally.
-- **If standalone (no directive):** Display the checkpoint content with the heading below. Stop generating and wait for the consultant's response.
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: file` (pipeline mode):** Write the checkpoint content above to `{outputs_dir}/CHECKPOINT_journey-builder.md` (the file named in your active mode block). Phase `1` ends this phase naturally and stops; phase `single` writes it for audit trail and continues immediately without stopping — see Mode: pipeline.
+- **`checkpoint: interactive` (standalone mode):** Display the checkpoint content with the heading below. Stop generating and wait for the consultant's response.
 - **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
 - **When triggered by the orchestrator:** The orchestrator MUST relay this checkpoint to the consultant. If the orchestrator cannot relay it, the journey builder MUST pause and log "BLOCKED: Awaiting consultant response to Checkpoint #1" in the journal.
 
@@ -282,6 +276,15 @@ For each step in the Backbase-enabled future journey:
 
 ### Phase 3: Journey Validation (Checkpoint #2)
 
+**Standalone mode only.** Per Decision 4 (see `## Modes` below), neither
+legacy pipeline prompt (single-phase or interactive Phase 2) ever
+implemented a second stop-and-wait checkpoint — pipeline mode goes straight
+from the approved Checkpoint #1 to finalized output. In pipeline mode,
+treat this section as always falling into the "no consultant response is
+possible" branch below (auto-approve, log the WARNING, set
+`consultant_validated: false`) rather than presenting the checkpoint. See
+Mode: pipeline for the exact phase behavior.
+
 **After building draft journey maps, present to the consultant for validation.**
 
 ```markdown
@@ -318,9 +321,9 @@ For each step in the Backbase-enabled future journey:
 
 This is a MANDATORY consultant checkpoint. If you skip it, the engagement is invalid. This is NON-NEGOTIABLE.
 
-**Checkpoint delivery (dual-mode):**
-- **If PHASE DIRECTIVE present:** Write the checkpoint content above to the checkpoint file specified in the directive. End this phase naturally.
-- **If standalone (no directive):** Display the checkpoint content with a `## CHECKPOINT #2` heading. Stop generating and wait for the consultant's response.
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: interactive` (standalone mode):** Display the checkpoint content with a `## CHECKPOINT #2` heading. Stop generating and wait for the consultant's response.
+- **`checkpoint: file` (pipeline mode):** Does not apply — pipeline mode never runs this checkpoint (see the standalone-only note atop this Phase 3 section, and Mode: pipeline).
 - **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
 
 **Rules:**
@@ -352,6 +355,12 @@ Follow the markdown template in `templates/outputs/journey_maps.md` exactly. Ens
 - Aggregate summary appears at the end
 
 #### 4c: Write Journal Entry
+
+In pipeline mode phase `single`, skip this step entirely — OUTPUT
+DISCIPLINE suppresses journal entries for that phase (audit lives in the
+checkpoint file instead; see Mode: pipeline). In pipeline mode phase `2`
+and in standalone mode (after Checkpoint #2), write the journal entry
+below.
 
 Append to `ENGAGEMENT_JOURNAL.md`:
 
@@ -458,3 +467,138 @@ When you complete your work, your journal entry MUST include a telemetry block:
 ```
 
 If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat) -->
+```yaml
+params: [domain]   # {domain} in knowledge paths below; ask if unclear from the request
+inputs:
+  required: []
+  optional:
+    - outputs/evidence_register.md
+    - outputs/pain_points.md
+    - outputs/metrics.md
+degraded: ask-inline
+knowledge:
+  - knowledge/domains/{domain}/journey_maps.md
+  - knowledge/domains/{domain}/personas.md
+  - knowledge/domains/{domain}/pain_points.md
+outputs:
+  - Journey Experience Map + per-journey swimlanes per Output Contract (inline, or journey_maps.json + journey_maps_summary.md if the consultant names an engagement directory)
+checkpoint: interactive
+phases: two-phase
+gates: []
+```
+
+Works from a bare "build journey maps" request — no engagement directory
+needed. If `{domain}` isn't clear from the request, ask before loading
+knowledge.
+
+**Evidence without a register:** the Input Contract's "never raw
+transcripts" rule guards against this agent going and reading transcript
+files itself — it does not prohibit consultant-supplied input.
+Consultant-pasted findings, quotes, or files they point you at ARE the
+evidence base; cite them the way you'd cite an evidence ID (e.g., "per
+consultant: ..."). `degraded: ask-inline` means: if there's no register AND
+the consultant hasn't given you findings, ask inline before mapping any
+journey — never silently build journeys without an evidence base.
+
+Standalone mode runs the full 3-phase, 2-checkpoint design exactly as
+written in Phase 1 through Phase 4 above: Phase 1 (Checkpoint #1 — Journey
+Selection) and Phase 3 (Checkpoint #2 — Journey Validation) are both
+delivered interactively. This is the fuller behavior the `.md` has always
+specified for direct/Task-tool use — the only spec standalone mode ever had
+(Decision 4).
+
+### Mode: pipeline
+<!-- orchestrate.py Block A. phase: "single" | "1" | "2" -->
+```yaml
+params: [engagement_dir, outputs_dir, domain, phase]
+inputs:
+  required:
+    - "{outputs_dir}/evidence_register.md"
+    - "{outputs_dir}/pain_points.md"
+    - "{outputs_dir}/metrics.md"
+  optional:
+    - "{outputs_dir}/stakeholder_intelligence.md"
+    - "{engagement_dir}/inputs/engagement_intake.md"
+    - "{outputs_dir}/CHECKPOINT_journey-builder_APPROVED.md"   # phase 2
+degraded: refuse
+knowledge:
+  - knowledge/domains/{domain}/journey_maps.md
+  - knowledge/domains/{domain}/personas.md
+  - knowledge/domains/{domain}/pain_points.md
+outputs:
+  - "{outputs_dir}/CHECKPOINT_journey-builder.md"
+  - "{outputs_dir}/journey_maps.json"
+  - "{outputs_dir}/journey_maps_summary.md"
+checkpoint: file
+phases: two-phase
+gates: []
+```
+
+PHASE DIRECTIVE: {phase} (single = Phase 1 + Phase 2 methodology in one run,
+no stop; 1 = Phase 1 selection + checkpoint only, ends the phase naturally;
+2 = Phase 2 construction + finalize, reading the approved checkpoint).
+
+Engagement directory: {engagement_dir}. Domain: {domain}. Read the inputs
+above before starting, plus the domain journey templates and personas
+listed in `knowledge` (Phase 0 and Phase 1 Step 1 depend on them).
+
+OUTPUT DISCIPLINE:
+- Do NOT explore the filesystem beyond the listed input and knowledge files.
+- If a listed file doesn't exist, skip it and proceed — do NOT retry.
+- Write ONLY the output files required by the active phase.
+- In phase `single` ONLY, do NOT write journal entries or update any other
+  files (audit lives in the checkpoint file — overrides the Telemetry
+  Protocol for that phase, same as the other Block-A agents' `single`
+  phase). In phases `1` and `2`, the core Telemetry Protocol applies; write
+  the Phase 4c journal entry once phase `2` produces the final deliverables.
+
+**DECISION-4 CONTRADICTION RESOLVED — checkpoint count and file names.** The
+`.md`'s (now-removed) Phase Execution Protocol table and the Phase 1/Phase 3
+headings describe a 3-phase design with two NON-NEGOTIABLE stop-and-wait
+checkpoints (`CHECKPOINT_journey_CP1.md` / `CHECKPOINT_journey_CP1_APPROVED.md`
+for Selection, `CHECKPOINT_journey_CP2.md` / `CHECKPOINT_journey_CP2_APPROVED.md`
+for Validation, with an intermediate "draft swimlanes" stop between them).
+Neither legacy pipeline prompt (single-phase or interactive Phase 1/Phase 2)
+ever implemented Checkpoint #2 or the intermediate draft-swimlanes stop —
+Phase 2 goes straight from the approved Checkpoint #1 to finalized
+`journey_maps.json` + `journey_maps_summary.md`. Both legacy prompts also
+read/write a single, differently-named checkpoint file —
+`CHECKPOINT_journey-builder.md` / `CHECKPOINT_journey-builder_APPROVED.md`
+(hyphenated, matching every other Block-A agent's
+`CHECKPOINT_{agent-name}.md` convention), not the `.md`'s `_CP1`/`_CP2`
+names. Per Decision 4 the injected prompt wins for pipeline: pipeline mode
+implements Checkpoint #1 (Journey Selection) only, using the hyphenated file
+names above. Checkpoint #2 (Journey Validation) never runs in pipeline
+mode — it is standalone-mode-only (see Mode: standalone and the note atop
+Phase 3). Where Phase 3's own rules already describe the no-consultant
+fallback ("log WARNING: Checkpoint #2 auto-approved... set
+consultant_validated: false"), pipeline mode always takes that fallback
+rather than presenting the checkpoint.
+
+Phase behavior:
+- **single**: STEP 1 — run Phase 0 (journey experience map) and Phase 1
+  Steps 1-4 (evidence density ranking); write
+  {outputs_dir}/CHECKPOINT_journey-builder.md with the ranked candidates
+  (for audit trail; do not stop). STEP 2 (continue immediately, do NOT
+  stop) — per Phase 1's "your recommendation" rule, treat the top 3-5
+  ranked journeys as selected; run Phase 2 (Steps 2a-2f) for each; write
+  {outputs_dir}/journey_maps.json and {outputs_dir}/journey_maps_summary.md
+  per Phase 4a/4b. Log the Checkpoint #2 auto-approval fallback per the
+  resolution above; set `metadata.consultant_validated: false`.
+- **1**: Run Phase 0 and Phase 1 Steps 1-4 as above; write
+  {outputs_dir}/CHECKPOINT_journey-builder.md; end the phase naturally — the
+  consultant reviews and selects journeys (Checkpoint #1).
+- **2**: Read {outputs_dir}/CHECKPOINT_journey-builder_APPROVED.md and the
+  draft {outputs_dir}/CHECKPOINT_journey-builder.md; run Phase 2 (Steps
+  2a-2f) for the consultant-selected journeys; write
+  {outputs_dir}/journey_maps.json and {outputs_dir}/journey_maps_summary.md
+  per Phase 4a/4b. Log the Checkpoint #2 auto-approval fallback per the
+  resolution above; set `metadata.consultant_validated: false` (Checkpoint
+  #1 passed; Checkpoint #2 did not run).

--- a/.claude/agents/roadmap-prioritization.md
+++ b/.claude/agents/roadmap-prioritization.md
@@ -17,27 +17,27 @@ You MUST read and follow `knowledge/standards/context_management_protocol.md` be
 - Check file sizes before reading (wc -l)
 - Chunk files over 500 lines
 - Read only upstream agent outputs (capability assessment, ROI report), never raw transcripts
+  (this guards against YOU going and opening transcript files yourself — it
+  does not prohibit consultant-pasted content in standalone mode; see Mode:
+  standalone below, same interpretation as capability-assessment's 2afba5d)
 - Write large outputs incrementally to disk
-- Append journal entry to ENGAGEMENT_JOURNAL.md when done
+- Append journal entry to ENGAGEMENT_JOURNAL.md when done (no phase in this
+  agent's pipeline mode suppresses this — see Mode: pipeline)
 
 ## Required Inputs
 
-Before creating a roadmap, you must have or request:
-1. **Capability Gap Analysis** - From Capability Agent — **read this, not raw transcripts**
-2. **ROI Value Levers** - From ROI Agent: quantified benefits, assumptions, measurement approach
-3. **Domain Context** - Journey catalog and domain pack information when available
-4. **Organizational Constraints** - Budget cycles, resource availability, strategic timing
+Defined per mode in `## Modes` below — standalone hard-requires both a
+**Capability Gap Analysis** and **ROI Value Levers** in some form (a file, or
+consultant-pasted equivalent) before sequencing anything (`degraded:
+ask-inline`); pipeline requires `capability_assessment.md`, `roi_report.md`,
+and `evidence_register.md` per its `inputs.required` contract (`degraded:
+refuse`). This is the input-side enforcement of the Traceability Requirement
+below — see that section for why both are non-negotiable in every mode.
 
-## Phase Execution Protocol
-
-This agent executes in **2 phases** with a consultant checkpoint between them.
-
-| Phase | Action | Reads | Writes |
-|-------|--------|-------|--------|
-| **Phase 1** | Read capability assessment + ROI outputs. Propose phased roadmap candidates, dependency map, and value milestones. | Capability gap analysis, ROI value levers, domain context | `CHECKPOINT_roadmap.md` with proposed phasing + initiative candidates |
-| **Phase 2** | Read approved checkpoint. Finalize roadmap with approved phasing, timelines, and dependencies. | `CHECKPOINT_roadmap_APPROVED.md` | `roadmap.md` (final deliverable) |
-
-**Phase transitions:** Phase 1 ends at the checkpoint. Phase 2 begins only after the consultant approves (or the orchestrator provides `CHECKPOINT_roadmap_APPROVED.md`).
+Also gather when available (free-form context, no formal file contract in
+either mode):
+- **Domain Context** - Journey catalog and domain pack information when available
+- **Organizational Constraints** - Budget cycles, resource availability, strategic timing
 
 ## Consultant Checkpoint (MANDATORY)
 
@@ -56,9 +56,9 @@ This agent executes in **2 phases** with a consultant checkpoint between them.
 
 ### Format:
 
-**Checkpoint delivery (dual-mode):**
-- **If PHASE DIRECTIVE present:** Write the checkpoint content above to the checkpoint file specified in the directive. End this phase naturally.
-- **If standalone (no directive):** Display the checkpoint content with a `## DECISION REQUIRED` heading. Stop generating and wait for the consultant's response.
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: file` (pipeline mode):** Write the checkpoint content above to `{outputs_dir}/CHECKPOINT_roadmap.md` (the file named in your active mode block). End this phase naturally.
+- **`checkpoint: interactive` (standalone mode):** Display the checkpoint content with a `## DECISION REQUIRED` heading. Stop generating and wait for the consultant's response.
 - **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
 
 Show 2-3 phasing options with pros/cons for each.
@@ -129,11 +129,20 @@ You MUST sequence initiatives based on:
 ## Critical Rules
 
 ### Traceability Requirement
-Every initiative MUST map to:
+
+**This is CORE identity — it applies in every mode, standalone and pipeline
+alike; no mode block below overrides it.** Every initiative MUST map to:
 - At least ONE capability gap from the assessment
 - At least ONE value lever from the ROI model
 
 If an initiative cannot be traced to both, it should be questioned or removed.
+
+This rule is also why the method **hard-requires** both a gap analysis and
+value levers as inputs (see Required Inputs above): without both, there is
+no basis to trace initiatives, and you must NOT invent gaps or levers to
+manufacture one. Standalone mode's `degraded: ask-inline` and pipeline
+mode's `degraded: refuse` both enforce this at the input boundary, before
+any sequencing work begins — not just at output review.
 
 ### Assumption Handling
 When sequencing requires assumptions:
@@ -209,6 +218,11 @@ When roadmap is complete:
 
 ## Journal Entry (MANDATORY)
 
+Unlike its Block A siblings, no phase of this agent's pipeline mode
+suppresses this section — see the Decision-4 note in Mode: pipeline for why
+(none of the legacy roadmap prompts, including single-pass, ever contained
+suppression language).
+
 After completing your work, append an entry to `ENGAGEMENT_JOURNAL.md` in the engagement directory. Include:
 - Which input files were consumed
 - Phasing model chosen and rationale
@@ -256,3 +270,122 @@ If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
 - Offer alternatives when trade-offs exist
 - Be direct about risks and concerns
 - Write for executive audience: clear, concise, decision-oriented
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat) -->
+```yaml
+inputs:
+  required: []
+  optional:
+    - outputs/capability_assessment.md
+    - outputs/roi_report.md
+    - outputs/evidence_register.md
+degraded: ask-inline
+knowledge: []
+outputs:
+  - Roadmap deliverable per Output Format (inline, or a file the consultant names)
+checkpoint: interactive
+phases: two-phase
+gates: []
+```
+
+Works from a bare "build the roadmap" request — no engagement directory
+needed.
+
+**Hard requirement, not a soft preference:** per the Traceability Requirement
+(Critical Rules, above), this agent cannot sequence a single initiative
+without BOTH a capability gap analysis and ROI value levers — a file each,
+or consultant-pasted equivalents (the "never raw transcripts" rule in
+Governing Protocol guards against self-directed reads, not consultant-
+supplied input; cite pasted content the way you'd cite an evidence ID, e.g.
+"per consultant: ..."). `degraded: ask-inline` means: if either is missing
+in any form, STOP and ask inline before proposing any phasing, stating the
+minimum viable input plainly — e.g. "To sequence a roadmap I need, at
+minimum: (1) a short list of the capability gaps you want addressed, even
+informally described, and (2) a short list of the value levers/benefits
+tied to them, even directionally sized." Never invent gaps or levers to fill
+the silence — a roadmap built on invented inputs violates the Traceability
+Requirement by construction.
+
+Deliver the Consultant Checkpoint interactively before finalizing (see
+Consultant Checkpoint above).
+
+### Mode: pipeline
+<!-- orchestrate.py step_roadmap. phase: "single" | "1" | "2" -->
+```yaml
+params: [engagement_dir, outputs_dir, phase]
+inputs:
+  required:
+    - "{outputs_dir}/capability_assessment.md"
+    - "{outputs_dir}/roi_report.md"
+    - "{outputs_dir}/evidence_register.md"
+  optional:
+    - "{outputs_dir}/CHECKPOINT_roadmap_APPROVED.md"   # phase 2
+degraded: refuse
+knowledge: []
+outputs:
+  - "{outputs_dir}/CHECKPOINT_roadmap.md"   # phases 1 (and single, see note)
+  - "{outputs_dir}/roadmap.md"
+checkpoint: file
+phases: two-phase
+gates: []
+```
+
+PHASE DIRECTIVE: {phase} (single = both steps in one run, no stop; 1 =
+propose phasing + checkpoint only, ends the phase naturally; 2 = finalize
+the roadmap from the approved checkpoint).
+
+Engagement directory: {engagement_dir}. Read the inputs listed above before
+starting.
+
+**DECISION-4 CONTRADICTION RESOLVED — required inputs.** `step_roadmap`'s
+legacy single-pass prompt reads all three files above; its interactive
+Phase 1 prompt reads only the first two, never `evidence_register.md`.
+Per Decision 4 and the capability-assessment (2afba5d) / journey-builder
+(2636eec) precedent — mode-level `inputs.required` is the superset across an
+agent's legacy prompt variants, with per-phase behavior below stating what
+each phase's own legacy prompt actually read — `evidence_register.md` is
+required for the whole pipeline mode (checked before every phase). This
+guarantees the file exists; it does not force phases 1/2 to newly cite it.
+
+**DECISION-4 CONTRADICTION RESOLVED — journal suppression.** Every other
+extracted Block A agent's legacy single-phase prompt explicitly suppressed
+journal writing ("Do NOT write journal entries..."). None of `step_roadmap`'s
+legacy prompts — single-pass, Phase 1, or Phase 2 — contain that
+instruction. Per Decision 4, no override means the core Journal Entry and
+Telemetry Protocol sections apply as written in every phase, including
+`single` — a deliberate divergence from the other Block A agents, not an
+oversight: phase `single` also never writes a checkpoint file (below), so
+the journal entry is its only audit trail.
+
+OUTPUT DISCIPLINE:
+- Do NOT explore the filesystem beyond the listed input files.
+- If a listed optional file doesn't exist, skip it and proceed — do NOT retry.
+- Write ONLY the output files required by the active phase (see Phase
+  behavior below — phase `single` does NOT write `CHECKPOINT_roadmap.md`;
+  only phases `1` and `2` touch it).
+- Write the Journal Entry and Telemetry Protocol block in every phase — see
+  the Decision-4 note above.
+
+Phase behavior:
+- **single**: Read the three required inputs. Propose phasing, sequencing,
+  dependencies, and value milestones per Roadmap Structure/Sequencing Logic
+  above, then immediately finalize — do NOT stop for the checkpoint and do
+  NOT write `{outputs_dir}/CHECKPOINT_roadmap.md` (matches legacy: single-pass
+  never produced a checkpoint file, unlike single-phase in the other Block A
+  agents). Write `{outputs_dir}/roadmap.md` per Output Format. Note in the
+  journal entry that phasing was auto-approved without a consultant
+  checkpoint (no consultant response is possible in this phase).
+- **1**: Read `capability_assessment.md` and `roi_report.md` (evidence
+  register existence is preflight-checked but not itself re-cited here, per
+  the note above). Propose phasing candidates per the Consultant Checkpoint
+  section above; write `{outputs_dir}/CHECKPOINT_roadmap.md`; end the phase
+  naturally — the consultant reviews and responds.
+- **2**: Read `{outputs_dir}/CHECKPOINT_roadmap_APPROVED.md` (and the draft
+  `{outputs_dir}/CHECKPOINT_roadmap.md` for the proposal it approved).
+  Finalize the roadmap with the approved phasing, timelines, and
+  dependencies; write `{outputs_dir}/roadmap.md` per Output Format.

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -782,31 +782,15 @@ Domain: {domain}
 
         log_step("2", "PARALLEL BLOCK A — Single-Phase (5 agents, non-interactive)")
 
-        jb_prompt = f"""PHASE DIRECTIVE: Single-phase (non-interactive)
-{shared_context}
-
-Also read domain journey templates: knowledge/domains/{domain}/journey_maps.md
-Also read domain personas: knowledge/domains/{domain}/personas.md
-
-OUTPUT DISCIPLINE:
-- Do NOT explore the filesystem beyond the listed input files.
-- If a file doesn't exist, skip it and proceed — do NOT retry.
-- Write ONLY the required output files listed below.
-
-STEP 1 — Analysis & Checkpoint:
-Analyze evidence density across customer journeys. Recommend the top 3-5
-journeys for mapping based on evidence volume and value leakage potential.
-Write checkpoint to: {outputs_dir}/CHECKPOINT_journey-builder.md (for audit trail)
-
-STEP 2 — Final Output (continue immediately, do NOT stop):
-Build detailed journey swimlane maps with value leakage quantification.
-Produce future-state Backbase-enabled swimlanes.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/journey_maps.json
-- {outputs_dir}/journey_maps_summary.md
-Do NOT write journal entries or update other files.
-"""
+        # journey-builder is mode-extracted (skill-first contracts): its
+        # prompt is composed from .claude/agents/journey-builder.md
+        # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+        jb_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+            "phase": "single",
+        }
 
         # market-context-researcher is mode-extracted (skill-first contracts):
         # its prompt is composed from .claude/agents/market-context-researcher.md
@@ -874,7 +858,8 @@ Do NOT write journal entries or update other files.
 
         # Block A1: 5 agents in parallel (hypothesis builder replaces monolithic ROI)
         results = await asyncio.gather(
-            _timed_agent("journey-builder", jb_prompt, "Journey Builder", 30),
+            _timed_agent("journey-builder", None, "Journey Builder", 30,
+                         mode="pipeline", params=jb_params),
             _timed_agent("market-context-researcher", None, "Market Context", 30,
                          mode="pipeline", params=mc_params),
             _timed_agent("capability-assessment", None, "Capability", 25,
@@ -960,17 +945,13 @@ Do NOT write journal entries or update other files.
         # ── Phase 1: Launch all 5 simultaneously ─────────────────────────
         log_step("2A", "PARALLEL BLOCK A — Phase 1 (5 agents simultaneously)")
 
-        jb_prompt = f"""PHASE DIRECTIVE: Phase 1 of 2
-{shared_context}
-
-Also read domain journey templates: knowledge/domains/{domain}/journey_maps.md
-Also read domain personas: knowledge/domains/{domain}/personas.md
-
-Analyze evidence density across customer journeys. Recommend the top 3-5
-journeys for mapping based on evidence volume and value leakage potential.
-
-Write: {outputs_dir}/CHECKPOINT_journey-builder.md
-"""
+        # journey-builder is mode-extracted: prompt composed from its own
+        # ## Modes contract (mode="pipeline", phase carried as a param).
+        jb_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+        }
 
         # market-context-researcher is mode-extracted: prompt composed from its
         # own ## Modes contract (mode="pipeline", phase carried as a param).
@@ -1008,7 +989,8 @@ Write: {outputs_dir}/CHECKPOINT_journey-builder.md
 
         # Fire all 5 simultaneously (hypothesis builder replaces monolithic ROI)
         results = await asyncio.gather(
-            run_agent("journey-builder", jb_prompt, engagement_dir, label="Journey Builder P1"),
+            run_agent("journey-builder", cwd=engagement_dir, label="Journey Builder P1",
+                      mode="pipeline", params={**jb_params, "phase": "1"}),
             run_agent("market-context-researcher", cwd=engagement_dir, label="Market Context P1",
                       mode="pipeline", params={**mc_params, "phase": "1"}),
             run_agent("capability-assessment", cwd=engagement_dir, label="Capability P1",
@@ -1033,20 +1015,6 @@ Write: {outputs_dir}/CHECKPOINT_journey-builder.md
 
         # ── Phase 2: Launch all 5 again ──────────────────────────────────
         log_step("2B", "PARALLEL BLOCK A — Phase 2 (5 agents simultaneously)")
-
-        jb2_prompt = f"""PHASE DIRECTIVE: Phase 2 of 2
-{shared_context}
-
-Read approved checkpoint: {outputs_dir}/CHECKPOINT_journey-builder_APPROVED.md
-Read draft checkpoint: {outputs_dir}/CHECKPOINT_journey-builder.md
-
-Build detailed journey swimlane maps with value leakage quantification.
-Produce future-state Backbase-enabled swimlanes.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/journey_maps.json
-- {outputs_dir}/journey_maps_summary.md
-"""
 
         roi_model_prompt = f"""PHASE DIRECTIVE: Phase 2 (Financial Modeling)
 {shared_context}
@@ -1074,7 +1042,8 @@ REQUIRED OUTPUT FILES (you MUST produce BOTH):
 """
 
         results = await asyncio.gather(
-            run_agent("journey-builder", jb2_prompt, engagement_dir, label="Journey Builder P2"),
+            run_agent("journey-builder", cwd=engagement_dir, label="Journey Builder P2",
+                      mode="pipeline", params={**jb_params, "phase": "2"}),
             run_agent("market-context-researcher", cwd=engagement_dir, label="Market Context P2",
                       mode="pipeline", params={**mc_params, "phase": "2"}),
             run_agent("capability-assessment", cwd=engagement_dir, label="Capability P2",

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -1093,55 +1093,32 @@ async def step_roadmap(
     start = time.time()
     cost = 0.0
 
+    # roadmap-prioritization is mode-extracted (skill-first contracts): its
+    # prompt is composed from .claude/agents/roadmap-prioritization.md
+    # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+    roadmap_params = {
+        "engagement_dir": engagement_dir,
+        "outputs_dir": outputs_dir,
+    }
+
     # S4 FIX: Single-pass in express OR non-interactive mode
     if express or non_interactive:
-        prompt = f"""Complete the full roadmap in a single pass.
-Engagement directory: {engagement_dir}
-
-Read:
-- {outputs_dir}/capability_assessment.md
-- {outputs_dir}/roi_report.md
-- {outputs_dir}/evidence_register.md
-
-Sequence initiatives by value, feasibility, and dependencies.
-Create initiative cards with decision gates.
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/roadmap.md
-"""
-        result = await run_agent("roadmap-prioritization", prompt, engagement_dir,
-                                 label="Roadmap (single-pass)", max_turns=20)
+        result = await run_agent("roadmap-prioritization", cwd=engagement_dir,
+                                 label="Roadmap (single-pass)", max_turns=20,
+                                 mode="pipeline", params={**roadmap_params, "phase": "single"})
         cost += result.total_cost_usd if result and result.total_cost_usd else 0
     else:
         # Phase 1
-        prompt = f"""PHASE DIRECTIVE: Phase 1 of 2
-Engagement directory: {engagement_dir}
-
-Read:
-- {outputs_dir}/capability_assessment.md
-- {outputs_dir}/roi_report.md
-
-Propose phasing and sequencing logic.
-
-Write: {outputs_dir}/CHECKPOINT_roadmap.md
-"""
-        result = await run_agent("roadmap-prioritization", prompt, engagement_dir, label="Roadmap P1")
+        result = await run_agent("roadmap-prioritization", cwd=engagement_dir, label="Roadmap P1",
+                                 mode="pipeline", params={**roadmap_params, "phase": "1"})
         cost += result.total_cost_usd if result and result.total_cost_usd else 0
 
         # T2 FIX: was express=False, now express=express
         present_checkpoint("roadmap", outputs_dir, express=express, non_interactive=non_interactive)
 
         # Phase 2
-        prompt = f"""PHASE DIRECTIVE: Phase 2 of 2
-Engagement directory: {engagement_dir}
-
-Read approved checkpoint: {outputs_dir}/CHECKPOINT_roadmap_APPROVED.md
-Read draft: {outputs_dir}/CHECKPOINT_roadmap.md
-
-REQUIRED OUTPUT FILES:
-- {outputs_dir}/roadmap.md
-"""
-        result = await run_agent("roadmap-prioritization", prompt, engagement_dir, label="Roadmap P2")
+        result = await run_agent("roadmap-prioritization", cwd=engagement_dir, label="Roadmap P2",
+                                 mode="pipeline", params={**roadmap_params, "phase": "2"})
         cost += result.total_cost_usd if result and result.total_cost_usd else 0
 
     assert_file_exists(outputs_dir / "roadmap.md", "Roadmap")


### PR DESCRIPTION
## Summary
PR 5 of the Skill-First Phase 1 cycle (Epic #98): journey-builder and roadmap-prioritization extracted. 7 of 10 extractions complete; only the three solo-PR agents remain (roi-financial-modeler, discovery, assembler).

## Tickets
- Closes #110 — B6: Extract journey-builder
- Closes #111 — B7: Extract roadmap-prioritization

## CONTRADICTION LOG (Decision 4 — reviewer-facing record)
**journey-builder (4):**
1. **The `.md`'s "two NON-NEGOTIABLE checkpoints" (CP1/CP2 protocol with dedicated filenames) never existed in production.** Every legacy invocation used the single `CHECKPOINT_journey-builder.md` — verified against the checkpoint machinery itself, which constructs filenames from the agent name and never supported a second file. Pipeline mode contracts Checkpoint #1 only (with the documented auto-approve fallback); Checkpoint #2 survives as standalone-only behavior.
2. "Never raw transcripts" resolved with the pasted-content interpretation (same as capability-assessment).
3. Per-phase journal suppression, phase single only (established precedent).
4. Telemetry Protocol block already present — no fix needed.
Also: `journey_maps.json` schema declared FROZEN in the shared Output Contract (cross-skill contract with /generate-assessment-html and the assembler); schema untouched.

**roadmap-prioritization (3):**
1. **Input divergence between legacy variants:** single-pass read 3 files, interactive P1 only 2 (never evidence_register.md). Resolved as superset-required — inert in practice because step ordering guarantees evidence_register.md exists before roadmap ever runs (documented in-file); per-phase prose records what each legacy phase actually read.
2. **Genuine sibling divergence, preserved not normalized:** NO legacy roadmap prompt ever suppressed journaling, and legacy single-pass never wrote an audit checkpoint. Both preserved exactly — the journal entry is single-pass's only audit trail, so suppressing it (to match Block-A siblings) would have been wrong.
3. Pasted-content evidence rule (same as siblings).

## Focus Areas
- The one-checkpoint resolution on journey-builder — the strongest case yet of aspirational `.md` spec vs production reality; verify via `git show 2636eec^:scripts/orchestrate.py` + grep for CP1/CP2 (zero journey hits).
- roadmap's superset-required preflight: contractually stricter for interactive P1, practically inert given DAG ordering — the in-file note is the load-bearing justification.

## Risk Flags
- [ ] Breaking changes: no
- [ ] Migration needed: no
- [x] Affects existing behavior: journey-builder pipeline runs now contractually promise ONE checkpoint (matching what always happened); no runtime delta

## Skip List
- File growth (+31% journey, +52% roadmap): documented-contradiction logging + small-file overhead; precedent accepted in PRs 3–4

## CI Coverage
- test_agent.py 106/106; unit rows 1.000 × 2; pipeline 1.000; gate BLOCKING post-#92

## Testing
- Composed-vs-legacy instruction checks across all phase values for both agents; per-ticket verify green after every commit
- NOT tested: live SDK invocation through the mode path (same caveat as PRs #118/#119)

## Base-branch note
Stacked on `mariamt/20260724-skill-first-pr4` (PR #119). Review order: #92 → #116 → #117 → #118 → #119 → this.
