### PR TITLE
feat(skill-first): PR 6 — roi-financial-modeler extracted, 3 modes + cap gate (#112)

### DIFF
--- a/.claude/agents/roi-financial-modeler.md
+++ b/.claude/agents/roi-financial-modeler.md
@@ -23,6 +23,10 @@ All visual outputs MUST follow the **Unified Design System** at `knowledge/desig
 
 ## Required Inputs
 
+> Which of these are required vs. optional for a given invocation — and which
+> files must exist before you start — is governed by the active mode contract
+> in `## Modes` below. This list is the master catalog.
+
 1. **Lever candidates** — `lever_candidates.md` or `CHECKPOINT_roi_levers_APPROVED.md` from the hypothesis builder. This contains the validated lever list with four-link chains.
 2. **Domain benchmarks** — `knowledge/domains/{domain}/benchmarks.md`
 3. **Domain ROI levers** — `knowledge/domains/{domain}/roi_levers.md` (if exists) — for calculation templates and typical ranges
@@ -485,16 +489,12 @@ Apply from `knowledge/standards/benchmark_evolution.md`:
 
 ---
 
-## Phase Execution
+## Checkpoint Content (per active mode)
 
-This agent executes in **2 phases** with one consultant checkpoint:
-
-| Phase | Action | Reads | Writes |
-|-------|--------|-------|--------|
-| **Phase 1** | Read lever candidates + domain data. Compute gap-based impacts. Run ROI self-check. If below range: adjust per self-check steps 1-5. Build model with 3 scenarios. Run reasonableness checks. | lever_candidates.md, benchmarks, questionnaire | `CHECKPOINT_roi_model.md` with model results + ROI self-check |
-| **Phase 2** | Read approved checkpoint. Finalize deliverables. | `CHECKPOINT_roi_model_APPROVED.md` | `roi_report.md` + `roi_config.json` |
-
-**Checkpoint content:**
+How the checkpoint is DELIVERED is mode-specific (see `## Modes` below —
+`checkpoint: interactive` presents it in conversation; `checkpoint: file`
+writes `CHECKPOINT_roi_model.md` as an audit trail). Whatever the delivery,
+the checkpoint content is:
 - **ROI Self-Check** — curve-adjusted ROI, benchmark comparison, adjustments made (if any)
 - Per-lever gap-based calculations (shown with full derivation)
 - 3-scenario summary table (NPV, ROI, payback)
@@ -557,10 +557,255 @@ If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
 
 ---
 
-## Excel Model (DO NOT GENERATE DIRECTLY)
+## Excel Model (mode-scoped)
 
-You produce `roi_config.json`. The orchestrator invokes `roi_excel_generator.py` to produce the Excel file. You do NOT call the generator yourself.
+In the **modeling modes (`standalone`, `pipeline`): DO NOT GENERATE THE EXCEL FILE.** You produce `roi_config.json`; the orchestrator (or `/generate-roi-excel`) invokes `roi_excel_generator.py` to produce the Excel file. You do NOT call the generator yourself in those modes.
+
+The single exception is the **`excel-source` mode** (see `## Modes` below): that is a separate re-invocation of this agent whose entire job IS Excel generation from an already-final, gate-capped `roi_config.json`, following `.claude/commands/generate-roi-excel.md`.
 
 The Excel model expects the `value_lever_groups` structure in the config. Ensure every driver has `baseline_formula`, `baseline_annual` > 0, and `backbase_impact` as an input key.
 
-**File naming:** `YYMM_[CLIENT_CODE]_ROI_Model.xlsx` (handled by orchestrator/generator, not you).
+**File naming:** `YYMM_[CLIENT_CODE]_ROI_Model.xlsx` (handled by the generator layer — orchestrator/`excel-source` run — never by a modeling-mode run).
+
+## Reasonableness Gate (cap_roi_config) — every mode that writes roi_config.json
+
+`roi_config.json` is **not final until the artifact-boundary cap gate has run**:
+
+```
+python3 scripts/artifact_boundary.py cap <path-to-roi_config.json>
+```
+
+It caps any `backbase_impact` over 0.60 in place (idempotent) and recomputes the curve-adjusted ROI against the segment benchmark ranges. The gate is **invoked by your caller, not by you**: `orchestrate.py` runs it immediately after the pipeline-mode run; `/build-roi` (step 5) runs it after a standalone run; `/generate-roi-excel` (step 3) re-runs it as a backstop before any Excel generation. The `gates: [cap_roi_config]` key in the mode contracts below DECLARES this guarantee — do not run the gate yourself, and never present the config as final before your caller has run it.
+
+## Schema Freeze (every mode)
+
+The "Output: roi_config.json Schema" and "Provenance Requirements" sections
+above are FROZEN and authoritative for `tools/roi_excel_generator.py`. Mode
+selection NEVER alters the schema — every mode that writes `roi_config.json`
+writes exactly that contract, in full, including the Sources array and the
+per-field `*_source`/`*_confidence` companions.
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+<!-- NOTE for editors: prose in this preamble (between "## Modes" and the first
+     "### Mode:") is DROPPED from composed prompts — put nothing load-bearing
+     here. Mode-independent rules belong in core sections above. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat), including
+     /build-roi step 4 after consultant validation of the levers -->
+```yaml
+params: [domain]   # {domain} in knowledge paths below; ask if unclear from the request
+inputs:
+  required: []
+  optional:
+    - outputs/lever_candidates.md                        # from roi-hypothesis-builder or /build-roi
+    - outputs/CHECKPOINT_roi_levers_APPROVED.md          # consultant-approved lever list
+    - outputs/market_context_validated.md
+    - outputs/capability_assessment.md
+    - outputs/benchmarks_validated.md
+    - inputs/[CLIENT]_Business_Case_Questionnaire_FILLED.xlsx   # client-confirmed baselines (input 7b)
+degraded: ask-inline
+knowledge:
+  - knowledge/domains/{domain}/benchmarks.md
+  - knowledge/domains/{domain}/roi_levers.md             # optional — if it exists
+  - "knowledge/Consulting Playbook Metrics Benchmark [Master] - Benchmarks.csv"   # Grep-filter only — never read whole
+  - knowledge/standards/ramp_up_models.md
+  - knowledge/standards/benchmark_evolution.md
+outputs:
+  - roi_report.md + roi_config.json (written to the outputs/ directory the consultant names, with an inline summary in conversation)
+checkpoint: interactive
+phases: two-phase
+gates: [cap_roi_config]   # declaration — /build-roi step 5 invokes it after this run; see Reasonableness Gate above
+```
+
+Entry paths: `/build-roi` step 4 (hypothesis-builder levers validated by the
+consultant) or direct invocation with a hand-provided lever list — "I have a
+list of 6 value levers for BECU. Build the ROI model from them." is a complete
+standalone request. Consultant-pasted levers ARE a valid lever source: cite
+them as "per consultant: ..." the way you would an evidence ID.
+
+`degraded: ask-inline` means: if there are NO levers in any form — no
+`lever_candidates.md`, no approved checkpoint, no pasted list — STOP and ask
+inline before modeling anything. You never identify levers yourself (core
+identity above): point the consultant at the `roi-hypothesis-builder` agent or
+`/build-roi`, and state the minimum viable input plainly — a lever list with,
+per lever, the KPI it moves, the Backbase capability behind it, and any current
+metric known. Never invent levers to fill the silence.
+
+Standalone keeps this agent's full two-phase checkpoint protocol (Decision 4 —
+the `.md` is the only spec standalone ever had): Phase 1 — size every lever
+(P1/P2/P3 evidence), build the 3-scenario model, run the ROI Self-Check and
+Reasonableness Checks, then present the Checkpoint Content (see section above)
+interactively and wait for consultant approval (if the consultant named an
+engagement directory, also write `CHECKPOINT_roi_model.md` there for the audit
+trail). Phase 2 — after approval, finalize `roi_report.md` + `roi_config.json`.
+
+The config you write follows the Schema Freeze section above — the standalone
+path produces byte-for-byte the same `roi_config.json` contract as the
+pipeline. It is not final until your caller runs the cap gate (`/build-roi`
+step 5; `/generate-roi-excel` re-runs it before Excel). Say so when you hand
+the model over — never present pre-gate numbers as final.
+
+### Mode: pipeline
+<!-- orchestrate.py Ignite Assess pipeline. Two invocation shapes:
+     phase "single" = non-interactive Block A2 (sequential, after Block A1
+     produced lever_candidates.md); phase "2" = interactive Block A Phase 2
+     (after the consultant approved CHECKPOINT_roi_levers). There is no
+     pipeline phase "1" for this agent — the ROI pair's Phase 1 is the
+     roi-hypothesis-builder. -->
+```yaml
+params: [engagement_dir, outputs_dir, domain, phase]
+inputs:
+  required:
+    - "{outputs_dir}/lever_candidates.md"
+    - "{outputs_dir}/evidence_register.md"
+    - "{outputs_dir}/pain_points.md"
+    - "{outputs_dir}/metrics.md"
+  optional:
+    - "{outputs_dir}/stakeholder_intelligence.md"
+    - "{engagement_dir}/inputs/engagement_intake.md"
+    - "{outputs_dir}/CHECKPOINT_roi_levers_APPROVED.md"   # phase 2 — mandatory read in that phase (written by the checkpoint gate)
+    - "{outputs_dir}/CHECKPOINT_roi_levers.md"            # phase 2 — the draft the approval refers to
+    - "{outputs_dir}/capability_assessment.md"
+    - "{outputs_dir}/market_context_validated.md"
+    - "{outputs_dir}/benchmarks_validated.md"
+degraded: refuse
+knowledge:
+  - knowledge/domains/{domain}/benchmarks.md
+  - knowledge/domains/{domain}/roi_levers.md             # optional — if it exists
+  - "knowledge/Consulting Playbook Metrics Benchmark [Master] - Benchmarks.csv"   # Grep-filter only — never read whole
+  - knowledge/standards/ramp_up_models.md
+  - knowledge/standards/benchmark_evolution.md
+outputs:
+  - "{outputs_dir}/CHECKPOINT_roi_model.md"   # phase single ONLY (audit trail — no approval loop)
+  - "{outputs_dir}/roi_report.md"
+  - "{outputs_dir}/roi_config.json"
+checkpoint: file
+phases: single
+gates: [cap_roi_config]   # declaration — orchestrate.py invokes it immediately after this run; see Reasonableness Gate above
+```
+
+PHASE DIRECTIVE: {phase} (single = non-interactive Block A2, journal
+suppressed; 2 = interactive Block A's Phase 2 — Financial Modeling — journal
+not suppressed). Each value is one single-pass invocation: this agent is never
+re-invoked for a second phase of its own inside the pipeline, and it NEVER
+pauses on `CHECKPOINT_roi_model.md` awaiting approval — the consultant
+approval that gates it is the roi_levers checkpoint owned by the
+roi-hypothesis-builder (see the Decision-4 note below).
+
+Engagement directory: {engagement_dir}. Domain: {domain}. Read the required
+inputs above before starting — `lever_candidates.md` is your work order; the
+discovery outputs (evidence register, pain points, metrics, plus the optional
+stakeholder intelligence and engagement intake) supply the bank-specific
+baselines and volumes for Link 4, never new levers. The three optional
+cross-references (capability_assessment.md, market_context_validated.md,
+benchmarks_validated.md) are sibling Block-A outputs — try ONCE, skip if not
+found, do NOT retry.
+
+OUTPUT DISCIPLINE:
+- Do NOT explore the filesystem beyond the listed input and knowledge files.
+- If a listed optional file doesn't exist, skip it and proceed — do NOT retry.
+- Write ONLY the output files required by the active phase (see Phase
+  behavior below — phase `2` does NOT write `CHECKPOINT_roi_model.md`).
+- In phase `single` ONLY, do NOT write journal entries or update any other
+  files (audit lives in the checkpoint file, overriding the Journal Entry and
+  Telemetry Protocol sections). Phase `2` keeps the core Journal Entry and
+  Telemetry Protocol.
+
+For each lever in lever_candidates.md (both phases — the legacy production
+task, which is the methodology above in compressed form):
+1. Compute gap-based backbase_impact using the percentage point gap method
+2. Build baseline calculations with bank-specific data
+3. Define 3 scenarios (conservative/moderate/aggressive) with per-lever curves
+4. Run reasonableness checks (total benefit < 5% of revenue, no single lever > 2%)
+Then run the full ROI Self-Check before finalizing, per the core sections.
+`roi_config.json` follows the Schema Freeze section above — the frozen
+contract, in full, in both phases.
+
+Phase behavior:
+- **single**: Write `{outputs_dir}/CHECKPOINT_roi_model.md` (audit trail —
+  Checkpoint Content section above; no approval loop, no pause), then continue
+  immediately and write `{outputs_dir}/roi_report.md` +
+  `{outputs_dir}/roi_config.json`.
+- **2**: Read `{outputs_dir}/CHECKPOINT_roi_levers_APPROVED.md` (the
+  consultant's approval, written by the pipeline's checkpoint gate before this
+  phase launched) and the draft `{outputs_dir}/CHECKPOINT_roi_levers.md` it
+  refers to — incorporate any consultant feedback recorded there into lever
+  sizing. Write `{outputs_dir}/roi_report.md` + `{outputs_dir}/roi_config.json`
+  directly (matches legacy: interactive Phase 2 never wrote
+  `CHECKPOINT_roi_model.md`).
+
+**DECISION-4 CONTRADICTION RESOLVED — the CHECKPOINT_roi_model approval loop
+never ran in production.** This file's legacy "Phase Execution" table
+described a two-phase pipeline protocol (Phase 1 → `CHECKPOINT_roi_model.md`
+→ consultant approves → Phase 2 reads `CHECKPOINT_roi_model_APPROVED.md`).
+Neither production invocation ever did that: non-interactive `single` writes
+the checkpoint purely as an audit trail and finalizes in the same run;
+interactive phase `2` never touches it, and nothing in `orchestrate.py` ever
+reads or writes `CHECKPOINT_roi_model_APPROVED.md`. Per Decision 4 (injected
+prompt wins for pipeline), the pipeline mode is single-pass as contracted
+here; the two-phase approval protocol survives as STANDALONE mode's
+interactive checkpoint (the `.md` wins there).
+
+**DECISION-4 CONTRADICTION RESOLVED — required inputs.** The legacy
+non-interactive prompt listed `lever_candidates.md` + domain knowledge and
+carried the shared discovery context ("Read these discovery outputs before
+starting": evidence_register, pain_points, metrics, stakeholder_intelligence,
+intake); the legacy interactive Phase 2 prompt additionally read the two
+roi_levers checkpoint files. Per the roadmap-prioritization (a2f9e80) /
+journey-builder (2636eec) precedent — mode-level `inputs.required` is the
+superset across the legacy prompt variants, with checkpoint files
+phase-scoped in `optional` because the preflight check runs for EVERY phase
+and phase `single` predates any checkpoint — the discovery trio is required
+for the whole mode, and the roi_levers checkpoint pair is optional-bucket but
+a mandatory read in phase `2`. The `[CLIENT]_Business_Case_Questionnaire_FILLED.xlsx`
+is deliberately NOT listed in this mode: neither legacy pipeline prompt ever
+listed it, and the non-interactive prompt's output discipline forbade reading
+beyond listed files — production pipeline runs never consumed it (flagged in
+the extraction log; standalone mode DOES list it).
+
+### Mode: excel-source
+<!-- orchestrate.py step_generate_excel — a separate re-invocation of this
+     agent AFTER the pipeline (or /build-roi) produced and gate-capped
+     roi_config.json. Its entire job is Excel generation — the one exception
+     to "Excel Model (mode-scoped)" above. -->
+```yaml
+params: [engagement_dir, outputs_dir]
+inputs:
+  required:
+    - "{outputs_dir}/roi_config.json"
+    - "{outputs_dir}/roi_report.md"
+  optional: []
+degraded: refuse
+knowledge:
+  - .claude/commands/generate-roi-excel.md   # the operative skill — read and follow it (repo root, not the engagement directory)
+outputs:
+  - "{outputs_dir}/YYMM_[CLIENT_CODE]_ROI_Model.xlsx"
+checkpoint: none
+phases: single
+gates: [cap_roi_config]   # declaration — /generate-roi-excel step 3 re-runs the gate BEFORE generating (backstop); see Reasonableness Gate above
+```
+
+You are generating a ROI Excel model. Read and follow
+`.claude/commands/generate-roi-excel.md` (this is the injected production
+shape of this invocation). Read the ROI config at
+`{outputs_dir}/roi_config.json` and the ROI report at
+`{outputs_dir}/roi_report.md`. Generate the Excel model using the
+`tools/roi_excel_generator.py` generator (ROIModelGenerator) or by writing the
+Excel file directly, and write the output to `{outputs_dir}/`.
+
+Do NOT rebuild the financial model and do NOT change `roi_config.json`'s
+numbers — the config is the finished, schema-frozen source of truth. The one
+config mutation permitted in this mode is the skill's own step 3: re-running
+the cap gate (`python3 scripts/artifact_boundary.py cap`) exactly as
+`/generate-roi-excel` instructs — it is idempotent and exists so an uncapped
+config can never reach Excel. Re-read the config from disk after the gate and
+generate from the gated file.
+
+Journal Entry and Telemetry Protocol apply as written in the core sections
+(Decision 4: the legacy `step_generate_excel` prompt contained no suppression
+instruction — absence of an override means the core sections stand, per the
+roadmap-prioritization precedent of checking each legacy prompt individually).

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -761,19 +761,11 @@ async def step_parallel_block_a(
     """
     start = time.time()
     cost = 0.0
-    inputs_dir = engagement_dir / "inputs"
-    intake = inputs_dir / "engagement_intake.md"
 
-    # Shared input context for all agents
-    shared_context = f"""Engagement directory: {engagement_dir}
-Read these discovery outputs before starting:
-- {outputs_dir}/evidence_register.md
-- {outputs_dir}/pain_points.md
-- {outputs_dir}/metrics.md
-- {outputs_dir}/stakeholder_intelligence.md
-Engagement intake: {intake}
-Domain: {domain}
-"""
+    # The old `shared_context` f-string block (engagement dir + discovery
+    # outputs + intake + domain) is gone: all Block A agents are now
+    # mode-extracted, and each agent's ## Modes pipeline contract carries the
+    # discovery-output/intake/domain context as inputs + params instead.
 
     if non_interactive:
         # ── S1: SINGLE-PHASE (non-interactive) ──────────────────────────
@@ -896,38 +888,19 @@ Domain: {domain}
         if file_exists(outputs_dir / "lever_candidates.md"):
             log_step("2B", "ROI FINANCIAL MODEL — Sequential (reads Block A1 outputs)")
 
-            roi_model_prompt = f"""PHASE DIRECTIVE: Single-phase (non-interactive)
-{shared_context}
-
-Read validated lever candidates: {outputs_dir}/lever_candidates.md
-Also read: knowledge/domains/{domain}/benchmarks.md
-Also read: knowledge/domains/{domain}/roi_levers.md (if exists)
-
-OPTIONAL cross-references (try ONCE, skip if not found — do NOT retry):
-- {outputs_dir}/capability_assessment.md
-- {outputs_dir}/market_context_validated.md
-- {outputs_dir}/benchmarks_validated.md
-
-OUTPUT DISCIPLINE:
-- Do NOT explore the filesystem beyond the listed input files.
-- Write ONLY the required output files listed below.
-
-For each lever in lever_candidates.md:
-1. Compute gap-based backbase_impact using percentage point gap method
-2. Build baseline calculations with bank-specific data
-3. Define 3 scenarios (conservative/moderate/aggressive) with per-lever curves
-4. Run reasonableness checks (total benefit < 5% of revenue, no single lever > 2%)
-
-Write checkpoint to: {outputs_dir}/CHECKPOINT_roi_model.md (for audit trail)
-
-REQUIRED OUTPUT FILES (you MUST produce BOTH):
-- {outputs_dir}/roi_report.md
-- {outputs_dir}/roi_config.json
-Do NOT write journal entries or update other files.
-"""
+            # roi-financial-modeler is mode-extracted (skill-first contracts):
+            # its prompt is composed from .claude/agents/roi-financial-modeler.md
+            # (## Modes -> pipeline) via compose_prompt — no inline f-string.
+            roi_model_params = {
+                "engagement_dir": engagement_dir,
+                "outputs_dir": outputs_dir,
+                "domain": domain,
+                "phase": "single",
+            }
 
             result_a2 = await _timed_agent(
-                "roi-financial-modeler", roi_model_prompt, "ROI Financial Model", 25
+                "roi-financial-modeler", None, "ROI Financial Model", 25,
+                mode="pipeline", params=roi_model_params,
             )
             cost += result_a2.total_cost_usd if result_a2 and result_a2.total_cost_usd else 0
 
@@ -1016,30 +989,16 @@ Do NOT write journal entries or update other files.
         # ── Phase 2: Launch all 5 again ──────────────────────────────────
         log_step("2B", "PARALLEL BLOCK A — Phase 2 (5 agents simultaneously)")
 
-        roi_model_prompt = f"""PHASE DIRECTIVE: Phase 2 (Financial Modeling)
-{shared_context}
-
-Read validated lever candidates: {outputs_dir}/lever_candidates.md
-Read approved checkpoint: {outputs_dir}/CHECKPOINT_roi_levers_APPROVED.md
-Read draft checkpoint: {outputs_dir}/CHECKPOINT_roi_levers.md
-Also read: knowledge/domains/{domain}/benchmarks.md
-Also read: knowledge/domains/{domain}/roi_levers.md (if exists)
-
-OPTIONAL cross-references (if available):
-- {outputs_dir}/capability_assessment.md
-- {outputs_dir}/market_context_validated.md
-- {outputs_dir}/benchmarks_validated.md
-
-For each lever in lever_candidates.md:
-1. Compute gap-based backbase_impact using percentage point gap method
-2. Build baseline calculations with bank-specific data
-3. Define 3 scenarios (conservative/moderate/aggressive) with per-lever curves
-4. Run reasonableness checks (total benefit < 5% of revenue, no single lever > 2%)
-
-REQUIRED OUTPUT FILES (you MUST produce BOTH):
-- {outputs_dir}/roi_report.md
-- {outputs_dir}/roi_config.json
-"""
+        # roi-financial-modeler is mode-extracted (skill-first contracts): its
+        # prompt is composed from .claude/agents/roi-financial-modeler.md
+        # (## Modes -> pipeline, phase "2") via compose_prompt — no inline
+        # f-string. The modeler has no pipeline phase "1" of its own — the ROI
+        # pair's Phase 1 above was roi-hypothesis-builder.
+        roi_model_params = {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "domain": domain,
+        }
 
         results = await asyncio.gather(
             run_agent("journey-builder", cwd=engagement_dir, label="Journey Builder P2",
@@ -1048,7 +1007,8 @@ REQUIRED OUTPUT FILES (you MUST produce BOTH):
                       mode="pipeline", params={**mc_params, "phase": "2"}),
             run_agent("capability-assessment", cwd=engagement_dir, label="Capability P2",
                       mode="pipeline", params={**cap_params, "phase": "2"}),
-            run_agent("roi-financial-modeler", roi_model_prompt, engagement_dir, label="ROI Financial Model"),
+            run_agent("roi-financial-modeler", cwd=engagement_dir, label="ROI Financial Model",
+                      mode="pipeline", params={**roi_model_params, "phase": "2"}),
             run_agent("benchmark-librarian", cwd=engagement_dir, label="Benchmark P2",
                       mode="pipeline", params={**bench_params, "phase": "2"}),
             return_exceptions=True,
@@ -1866,22 +1826,20 @@ async def step_generate_excel(
         log("  ⚠ Skipping Excel — roi_config.json not found", C.YELLOW)
         return {"elapsed": 0, "cost": 0}
 
-    excel_prompt = f"""You are generating a ROI Excel model.
-
-Read and follow: {COMMANDS_DIR / 'generate-roi-excel.md'}
-
-Read the ROI config: {outputs_dir}/roi_config.json
-Read the ROI report: {outputs_dir}/roi_report.md
-
-Generate the Excel model using the roi_excel_generator tool or by writing
-the Excel file directly.
-
-Write the output to: {outputs_dir}/
-"""
+    # roi-financial-modeler is mode-extracted (skill-first contracts): the
+    # Excel re-invocation is composed from .claude/agents/roi-financial-modeler.md
+    # (## Modes -> excel-source) via compose_prompt — no inline f-string. The
+    # mode reads and follows .claude/commands/generate-roi-excel.md, which
+    # re-runs the cap gate (idempotent backstop) before generating.
+    excel_params = {
+        "engagement_dir": engagement_dir,
+        "outputs_dir": outputs_dir,
+    }
 
     result = await run_agent(
-        "roi-financial-modeler", excel_prompt, engagement_dir,
+        "roi-financial-modeler", cwd=engagement_dir,
         label="ROI Excel", max_turns=30,
+        mode="excel-source", params=excel_params,
     )
     cost += result.total_cost_usd if result and result.total_cost_usd else 0
 


### PR DESCRIPTION
## Summary
PR 6 of the Skill-First Phase 1 cycle (Epic #98): roi-financial-modeler extracted into three modes (`standalone`, `pipeline`, `excel-source`) with `gates: [cap_roi_config]` declared on every mode that writes `roi_config.json`. The canonical roi_config.json schema and PRD-v1 provenance requirements are byte-frozen (verified by diff against parent). Solo PR by design — this is the riskiest schema surface in the cycle.

## Tickets
- Closes #112 — B8: Extract roi-financial-modeler (3 modes + cap gate)

## CONTRADICTION LOG (Decision 4)
1. **The CHECKPOINT_roi_model approval loop never ran in production** — nothing ever read or wrote `CHECKPOINT_roi_model_APPROVED.md` (verified: the string appears nowhere in orchestrate.py at any commit). Pipeline mode is single-pass with an audit-trail checkpoint write; the two-phase interactive protocol survives as standalone behavior.
2. "DO NOT GENERATE EXCEL DIRECTLY" vs step_generate_excel instructing this same agent to generate Excel — rescoped: the ban binds modeling modes; `excel-source` is the sole, dedicated exception.
3. Required-inputs superset (established precedent); the roi_levers checkpoint pair sits in `optional` (preflight runs every phase; phase single predates any checkpoint) with a mandatory-read note for phase 2.
4. Journal suppression scoped per legacy prompt: phase single only; phase 2 and excel-source never suppressed.
5. **Flagged product call (not resolved here):** the FILLED business-case questionnaire is NOT consumed by pipeline mode — neither legacy pipeline prompt listed it and output discipline forbade off-list reads, so production never read it. Standalone lists it as optional input. If the pipeline *should* consume it, that's a future ticket.

## Also in this PR
- Removed the now-dead `shared_context` block from `step_parallel_block_a` — its only consumers were the modeler f-strings deleted here; all five Block-A agents are mode-extracted on ancestor commits. Reviewer verified its payload maps 1:1 onto the mode contracts (no information loss).

## Focus Areas
- Schema freeze: `## Output: roi_config.json Schema` + `## Provenance Requirements` byte-identical to parent (independently diffed in spec review).
- Placeholder hygiene: this file is full of literal `{token}` examples — all confirmed to live in core sections, never in mode blocks (a stray one would crash compose_prompt at runtime).
- The new core "Reasonableness Gate" and "Schema Freeze" sections — placed in core deliberately: composer drops `## Modes` preamble prose (recipe lesson learned this ticket).

## Risk Flags
- [ ] Breaking changes: no
- [ ] Migration needed: no
- [x] Affects existing behavior: pipeline mode now contractually single-pass (matching what always happened); no runtime delta

## CI Coverage
- test_agent.py 125/125; unit 1.000 (9 checks incl. provenance trio + #104 parity witness); pipeline 1.000; deliverable roi 1.000; gate BLOCKING post-#92

## Testing
- Composed-vs-legacy line-walk across all three recovered f-strings; negative preflight verified (refuses without lever_candidates.md)
- NOT tested: live SDK invocation through the mode path (cycle-wide caveat)

## Base-branch note
Stacked on `mariamt/20260724-skill-first-pr5` (PR #120). Review order: #92 → #116 → #117 → #118 → #119 → #120 → this.
