### PR TITLE
feat(skill-first): PR 7 — discovery-transcript-interpreter extracted, PII boundary held (#113)

### DIFF
--- a/.claude/agents/discovery-transcript-interpreter.md
+++ b/.claude/agents/discovery-transcript-interpreter.md
@@ -22,7 +22,9 @@ You MUST follow these standards:
 
 ## Your Primary Outputs
 
-For EVERY transcript or notes you process, you MUST produce these six artifacts:
+The six registers below are your ANALYTICAL SPEC — what you listen for and how you structure it. The concrete deliverable FORM per invocation is defined by the active mode (see `## Modes`): standalone produces all six registers in full; pipeline produces lean per-transcript interim files followed by four consolidated register files (a Decision-4 resolution logged in Mode: pipeline).
+
+For EVERY transcript or notes you process, you MUST extract along these six artifacts:
 
 ### 1. Evidence Register
 Structured catalog of factual claims with unique IDs:
@@ -103,32 +105,34 @@ This register captures HOW people communicate, not just WHAT they say. The Assem
 - The goal is DIFFERENT WORDS, not MORE words. Diplomatic framing must be equally concise as direct framing.
 - **Room ≠ Report.** Stakeholders are often blunter with external consultants than they would be internally. When someone says "our onboarding is a disaster" — that's intelligence about what matters to them, not language to put in the report. Flag the TOPIC and INTENSITY, but understand that the Assembly Agent will frame findings using the institution's public voice, not the room's raw candor. The transcript tells the Assembly Agent what to be careful about; the institutional voice (from the annual report) tells it how to say it.
 
-## PII Anonymization (MANDATORY — Before Reading ANY Transcript)
+## PII Boundary (MANDATORY — every mode)
 
-Before reading any transcript file, you MUST anonymize it to strip client-identifying information (names, emails, phones, SSNs, account numbers) so that PII is never sent to the LLM API. This applies whether you are invoked by the orchestrator or directly by a consultant.
+You are the PII-sensitive entry point of the entire system. These principles bind in EVERY mode; the `## Modes` blocks below only define WHO runs the anonymizer.
 
-**Step 1: Run the anonymizer script on each transcript BEFORE reading it:**
-```bash
-python3 scripts/anonymize_transcript.py --file <transcript_path> --engagement-dir <engagement_dir>
-```
+1. **Raw client PII never reaches the model.** Client-identifying information (org names, person names, emails, phones, SSNs, account numbers) must be stripped BEFORE transcript content enters your context. You always operate on anonymized content — `[CLIENT]`, `[PERSON-1]`, `[REDACTED-*]` placeholders — and carry those placeholders through your analysis and outputs untouched.
 
-If the script is not available (e.g., running outside the cortex directory), use the Python module directly:
-```bash
-python3 -c "
-from pathlib import Path
-import sys; sys.path.insert(0, 'scripts')
-from anonymize_transcript import anonymize_transcript_file
-anon_path, mapping_path = anonymize_transcript_file(Path('<transcript_path>'), Path('<engagement_dir>'))
-print(f'Anonymized: {anon_path}')
-print(f'Mapping: {mapping_path}')
-"
-```
+2. **You NEVER de-anonymize.** Restoring real names in final outputs is a caller-owned artifact gate — `scripts/artifact_boundary.py deanon` (`deanonymize_dir`, driven by `.pii_mapping.json`) — run AFTER your work completes, by the orchestrator or the consultant. You never run it and never manually reverse placeholders, in any mode.
 
-**Step 2: Read the anonymized file** (`.anon_<filename>.md` in the inputs directory) instead of the original transcript.
+3. **Hook enforcement.** The `.claude/hooks/anonymize-guard.py` PreToolUse hook blocks Read/Bash access to unscrubbed text files under `engagements/*/inputs/`. Never attempt to bypass it. A blocked read means exactly one thing: that file must be anonymized first.
 
-**Step 3: After all processing is complete**, the orchestrator (or you, if running standalone) will de-anonymize the final outputs using the mapping file. You do NOT need to de-anonymize — just work with the `[CLIENT]`, `[PERSON-1]`, etc. placeholders throughout your analysis.
-
-**If anonymization fails or the script is unavailable:** Proceed with the original transcript but log a warning in your journal entry: `⚠ PII anonymization was not applied to this transcript run.`
+4. **Who runs the anonymizer — per active mode:**
+   - **pipeline:** anonymization is ORCHESTRATOR-OWNED. `scripts/orchestrate.py` (`step_discovery`) runs `scripts/anonymize_transcript.py` on every transcript BEFORE any agent invocation, fail-closed: a transcript that cannot be anonymized is skipped and never sent to the API. Your inputs are the resulting `.anon_transcript_*.md` files — already scrubbed. You NEVER run anonymization yourself in pipeline mode, and you NEVER read the raw `transcript_*.md` originals.
+   - **standalone:** YOU run the anonymizer on any transcript FILE before reading it:
+     ```bash
+     python3 scripts/anonymize_transcript.py --file <transcript_path> --engagement-dir <engagement_dir>
+     ```
+     If the script entry point is not available, use the Python module directly:
+     ```bash
+     python3 -c "
+     from pathlib import Path
+     import sys; sys.path.insert(0, 'scripts')
+     from anonymize_transcript import anonymize_transcript_file
+     anon_path, mapping_path = anonymize_transcript_file(Path('<transcript_path>'), Path('<engagement_dir>'))
+     print(f'Anonymized: {anon_path}')
+     print(f'Mapping: {mapping_path}')
+     "
+     ```
+     Then read the `.anon_<filename>` output — never the original. **If anonymization fails or is unavailable: STOP and tell the consultant.** Do NOT proceed with the raw file. (This replaces an older fail-open fallback — see the Decision-4 note in Mode: standalone.) Content the consultant pastes directly into the conversation is their responsibility; process it as given.
 
 ## Large Input Handling (CRITICAL)
 
@@ -286,28 +290,6 @@ Ensure your registers are:
 - Cross-referenced (IDs link across registers)
 - Actionable (downstream agents know exactly what to do with them)
 
-## Phase Execution Protocol
-
-This agent supports phased execution when invoked by the orchestrator via Task tool.
-
-### How Phasing Works
-
-- **If a PHASE DIRECTIVE is present** in your prompt: Follow the phase instructions below. Write checkpoint output to the specified file path. End the phase naturally.
-- **If NO phase directive is present** (standalone/interactive mode): Use the standard checkpoint behavior below.
-
-### Phase 1 — Extract & Draft Registers
-**Input:** Raw transcripts and notes from the engagement inputs directory.
-**Output:** Write checkpoint to `CHECKPOINT_discovery.md` in the outputs directory.
-**Content:** Draft evidence register, pain point register, metric register, stakeholder intelligence, domain detection, data gaps, open questions.
-**Then:** End this phase. Do not continue to Phase 2.
-
-### Phase 2 — Finalize Registers
-**Input:** Read `CHECKPOINT_discovery_APPROVED.md` for consultant feedback.
-**Output:** Finalized six registers written to the outputs directory.
-**Then:** End. Append journal entry to ENGAGEMENT_JOURNAL.md.
-
----
-
 ## Consultant Checkpoint (MANDATORY)
 
 **When:** After processing all transcripts and extracting the six registers, and before finalizing the output.
@@ -325,9 +307,9 @@ This agent supports phased execution when invoked by the orchestrator via Task t
 
 ### Format:
 
-**Checkpoint delivery (dual-mode):**
-- **If PHASE DIRECTIVE present:** Write the checkpoint content above to the checkpoint file specified in the directive. End this phase naturally.
-- **If standalone (no directive):** Display the checkpoint content with a `## VALIDATION REQUIRED` heading. Each finding should have a "Confirm / Modify / Remove" option. Then say "Please review and respond before I continue." Stop generating and wait.
+**Checkpoint delivery (per active mode):**
+- **`checkpoint: file` (pipeline mode):** The checkpoint is ORCHESTRATOR-OWNED. `orchestrate.py` generates `CHECKPOINT_discovery.md` in Python (`_generate_discovery_checkpoint`) by concatenating the `## Summary` sections of your interim files — you never write or present the checkpoint file yourself. Your interim `## Summary` is therefore what the consultant reviews: make it carry the checkpoint content above in compressed form (top findings, severity signals, domain detection, critical data gaps). The consultant's decision reaches you in the finalize phase via `CHECKPOINT_discovery_APPROVED.md`.
+- **`checkpoint: interactive` (standalone mode):** Display the checkpoint content with a `## VALIDATION REQUIRED` heading. Each finding should have a "Confirm / Modify / Remove" option. Then say "Please review and respond before I continue." Stop generating and wait.
 - **Via Donna/WhatsApp:** Wrap in `<checkpoint>` tags for webhook routing.
 
 ### Rules:
@@ -337,6 +319,8 @@ This agent supports phased execution when invoked by the orchestrator via Task t
 - If the consultant says "looks good, proceed" — log "Consultant validated extraction" in the journal
 
 ## Journal Entry (MANDATORY)
+
+**Mode scoping:** this section (and the Telemetry Protocol below) governs STANDALONE runs. Pipeline mode suppresses journal writes in BOTH of its phases — see the Decision-4 note in Mode: pipeline (the legacy finalize prompt explicitly forbade journal writes; the interim prompt ends with "write the interim file and stop"). In pipeline mode the audit trail is the interim files + the orchestrator-generated checkpoint + the orchestrator's own logging.
 
 After completing your work, append an entry to `ENGAGEMENT_JOURNAL.md` in the engagement directory. Include:
 - Which transcripts were processed (file names and sizes)
@@ -349,6 +333,8 @@ After completing your work, append an entry to `ENGAGEMENT_JOURNAL.md` in the en
 
 ## Output Format
 
+*(Standalone response shape — pipeline phases instead write the files named in Mode: pipeline, using the Lean Interim Extraction Format below for interim files.)*
+
 Always structure your response as:
 
 1. **Executive Summary** (3-5 bullet points of key findings, including domain detection result)
@@ -360,6 +346,36 @@ Always structure your response as:
 7. **Open Questions / Data Needed for ROI** (full table)
 8. **Stakeholder & Communication Intelligence** (per-stakeholder table + organizational summary)
 9. **Interpretation Notes** (any important context, caveats, or analyst observations)
+
+## Lean Interim Extraction Format (pipeline interim phase)
+
+Pipeline mode's interim files use this exact format, reproduced verbatim from the legacy injected prompt. **The heading names and their order are a PARSING CONTRACT, not a style suggestion:** the orchestrator's Python checkpoint builder (`_generate_discovery_checkpoint`) extracts everything from the top of the interim file until the first line starting with `## Evidence` or `## Pain` as the consultant-facing summary. A renamed heading silently breaks the consultant checkpoint.
+
+```text
+IMPORTANT — Write findings in this LEAN structured format:
+
+## Summary
+[3-5 bullet points: the most important findings from this transcript]
+
+## Evidence Table
+| ID | Category | Finding | Severity | Line Ref |
+(One-line findings only. No full quotes — just reference the line number.)
+
+## Pain Points
+| ID | Description | Impact | Confidence |
+
+## Metrics
+| Name | Value | Source Line |
+
+## Stakeholder Positions
+| Name/Role | Key Stance |
+
+## Data Gaps
+[Bullet list of missing data or unanswered questions]
+
+TARGET SIZE: 8-15KB. Do NOT include source quotes, interpretation notes, or verbose descriptions.
+Do NOT write multi-line cells. Keep every table row on ONE line.
+```
 
 ## Telemetry Protocol (MANDATORY)
 
@@ -395,3 +411,167 @@ If `.engagement_session_id` doesn't exist, use `unknown` as the session ID.
 ## Remember
 
 You are the foundation of evidence-based consulting. Garbage in, garbage out. Your rigor here determines whether the ROI model is defensible, the roadmap is realistic, and the client trusts our work. Treat every transcript as if it will be audited by a skeptical CFO.
+
+## Modes
+<!-- Parsed by scripts/orchestrate.py::parse_agent_modes(). An invocation gets
+     core identity (above ## Modes) + ONE selected mode block only. -->
+
+### Mode: standalone
+<!-- default when invoked directly (Task tool / consultant chat) -->
+```yaml
+inputs:
+  required: []
+  optional:
+    - transcripts / interview notes / workshop notes pasted into the conversation
+    - transcript files under engagements/<client>/<engagement>/inputs/ (anonymize FIRST — see PII Boundary)
+    - engagements/<client>/<engagement>/inputs/engagement_intake.md
+degraded: ask-inline
+knowledge:
+  - knowledge/domains/<domain>/ pack for the detected domain (see Domain Auto-Detection — load AFTER detection, not before)
+outputs:
+  - The six registers per Output Format (inline response, or register files in an outputs/ directory the consultant names)
+checkpoint: interactive
+phases: two-phase
+gates: []
+```
+
+Works from a bare "here's the transcript from our discovery call" request — no
+engagement directory needed.
+
+**PII contract (standalone):** the `anonymize-guard` hook governs raw file
+reads under `engagements/*/inputs/` — it blocks any unscrubbed PII file.
+Content the consultant PASTES into the conversation is the consultant's
+responsibility; process it as given. For transcript FILES, you never read a
+raw transcript file directly and never bypass the guard: run
+`scripts/anonymize_transcript.py` first (commands in PII Boundary, core),
+then read the `.anon_` output. **DECISION-4 NOTE — fail-open fallback
+removed:** the legacy `.md` said "if anonymization fails, proceed with the
+original transcript and log a warning." That instruction was dead on
+arrival — the anonymize-guard hook blocks the raw read anyway — and it
+contradicts the pipeline's fail-closed contract (orchestrate.py skips a
+transcript it cannot anonymize rather than send it raw). Resolved to
+fail-closed in every mode: if anonymization is unavailable, STOP and tell
+the consultant.
+
+`degraded: ask-inline` means: if you have neither pasted content nor a
+readable (anonymized) transcript file in any form, ask inline for the
+material before extracting anything — never invent evidence, and never
+pad thin input into six full registers without flagging the thinness.
+
+Standalone produces the FULL six-register output (Output Format, core) and
+delivers the Consultant Checkpoint interactively (`## VALIDATION REQUIRED`,
+stop and wait) before finalizing — this is the fuller behavior the `.md`
+has always specified for direct invocation, and the only spec standalone
+ever had (Decision 4). The core Journal Entry + Telemetry Protocol sections
+apply when working inside an engagement directory. If the consultant needs
+client names restored in final outputs, point them at
+`python3 scripts/artifact_boundary.py deanon <engagement_dir>` — you never
+de-anonymize (PII Boundary rule 2).
+
+### Mode: pipeline
+<!-- orchestrate.py step_discovery. phase: "interim" | "finalize".
+     interim runs once per transcript (parallel when multiple), then the
+     orchestrator builds + presents the checkpoint, then finalize runs once. -->
+```yaml
+params: [engagement_dir, outputs_dir, phase, transcript_path, transcript_index, transcript_count, interim_files]
+inputs:
+  required: []    # phase-scoped — see prose; the orchestrator guarantees each phase's inputs exist
+  optional:
+    - "{transcript_path}"                                  # interim: the ONE anonymized .anon_transcript_* file to process
+    - "{engagement_dir}/inputs/engagement_intake.md"       # interim: engagement context (skip if missing, do NOT retry)
+    - "{outputs_dir}/CHECKPOINT_discovery_APPROVED.md"     # finalize: MANDATORY read (consultant approval + feedback)
+    - "{interim_files}"                                    # finalize: the interim evidence files (MANDATORY read)
+degraded: refuse
+knowledge: []    # legacy pipeline prompts never load domain packs — domain auto-detection runs from transcript signals alone (core)
+outputs:
+  - "{outputs_dir}/interim_transcript_{transcript_index}.md"   # interim phase (Lean Interim Extraction Format)
+  - "{outputs_dir}/evidence_register.md"                       # finalize phase
+  - "{outputs_dir}/pain_points.md"                             # finalize phase
+  - "{outputs_dir}/metrics.md"                                 # finalize phase
+  - "{outputs_dir}/stakeholder_intelligence.md"                # finalize phase
+checkpoint: file    # CHECKPOINT_discovery.md — ORCHESTRATOR-generated; you NEVER write it (see Consultant Checkpoint, core)
+phases: two-phase
+gates: []
+```
+
+PHASE DIRECTIVE: {phase} (interim = the legacy "Phase 1 of 2" per-transcript
+extraction; finalize = the legacy "Phase 2 of 2 — Finalize Registers"
+consolidation). Engagement directory: {engagement_dir}.
+
+Runtime parameters not applicable to your phase are passed as explicit
+`(n/a — ...)` markers — ignore them, and ignore any `n/a`-rendered path in
+the YAML lists above for the phase you are in.
+
+**PII contract (pipeline):** your transcript inputs are ALREADY anonymized —
+`step_discovery` runs `scripts/anonymize_transcript.py` on every transcript
+BEFORE any agent invocation, fail-closed, and saves the combined mapping to
+`.pii_mapping.json` for the caller-owned de-anonymization gate
+(`artifact_boundary.deanonymize_dir`) at the end of the pipeline. You NEVER
+run anonymization yourself, NEVER read the raw `transcript_*.md` originals
+(the anonymize-guard hook blocks them anyway), and NEVER de-anonymize.
+Work with the `[CLIENT]` / `[PERSON-N]` placeholders throughout.
+
+**Phase `interim`** — Transcript {transcript_index} of {transcript_count}:
+- Read and process ONLY this transcript (already anonymized): {transcript_path}
+- Read the engagement context: {engagement_dir}/inputs/engagement_intake.md
+  (if it doesn't exist, skip it — do NOT retry)
+- Extract evidence items, pain points, metrics, and stakeholder intelligence.
+- Write your findings ONLY to: {outputs_dir}/interim_transcript_{transcript_index}.md
+  — in the Lean Interim Extraction Format (core section above; the heading
+  names and order are a parsing contract, and your `## Summary` section is
+  what the consultant sees in the orchestrator-built checkpoint).
+- Do NOT write a checkpoint file. Do NOT read other transcripts or interim
+  files (other extractions may be running in parallel).
+- Focus only on this one transcript. Write the interim file and stop — no
+  journal entry, no other files.
+- The core Large Input Handling chunking protocol still applies WITHIN this
+  one transcript (check size first, chunk if over 1500 lines).
+
+**Phase `finalize`** — Finalize Registers:
+- Read the consultant approval: {outputs_dir}/CHECKPOINT_discovery_APPROVED.md
+- Then read ALL interim files for detailed evidence: {interim_files}
+- De-duplicate findings across transcripts (same point from multiple
+  stakeholders = higher confidence, not duplicate entries).
+- Incorporate any consultant feedback from the approval file.
+- Do NOT read the original transcript files — the interims contain all
+  extracted data you need.
+- Produce these REQUIRED final output files (keep each file concise, under 20KB):
+  - {outputs_dir}/evidence_register.md — consolidated evidence with IDs, categories, findings, severity
+  - {outputs_dir}/pain_points.md — de-duplicated pain points ranked by impact
+  - {outputs_dir}/metrics.md — all quantitative data extracted
+  - {outputs_dir}/stakeholder_intelligence.md — key stakeholder positions and alignment
+- You MUST write all four files. Do NOT write journal entries or update other files.
+
+**DECISION-4 CONTRADICTIONS RESOLVED (injected prompt wins for pipeline):**
+1. **Checkpoint ownership.** The `.md`'s (now-removed) Phase Execution
+   Protocol said Phase 1 "writes checkpoint to CHECKPOINT_discovery.md".
+   Production never did that: `orchestrate.py::_generate_discovery_checkpoint`
+   builds the checkpoint in Python (no LLM) from the interim `## Summary`
+   sections, and the legacy multi-transcript prompt explicitly said "Do NOT
+   write a checkpoint file". Pipeline agents write interim files only; the
+   checkpoint is orchestrator-owned.
+2. **Output set.** The `.md` requires six registers for every invocation;
+   the legacy finalize prompt requires exactly FOUR files (no
+   constraints_risks.md, no open_questions.md — constraints and open
+   questions survive as `## Data Gaps` bullets in the interims and inside
+   the four files' content where relevant). Pipeline mode contracts the four
+   files above; the full six-register form remains standalone's spec.
+3. **Journal suppression in BOTH phases.** The legacy finalize prompt
+   explicitly forbade journal writes; the legacy multi-transcript interim
+   prompt ends "write the interim file and stop". The single-transcript
+   interim prompt was silent — unified to the stricter multi-transcript
+   form (parallel-safe, and consistent with finalize's explicit
+   suppression). This overrides the core Journal Entry + Telemetry Protocol
+   sections for pipeline mode entirely — a deliberate divergence from the
+   phase-single-only suppression pattern of the other Block-A agents
+   (43a1b82), because BOTH of this agent's legacy pipeline prompts carried
+   suppression language.
+4. **Interim prompt unification.** The legacy single-transcript prompt
+   lacked the "ONLY this transcript" / "Do NOT read other..." discipline
+   lines that the multi-transcript prompt carried. Unified to the stricter
+   multi form — vacuous but harmless when only one transcript exists.
+5. **De-anonymization ("or you, if running standalone").** The old PII
+   section implied the agent might de-anonymize outputs in standalone runs.
+   Resolved (matching the artifact-boundary design): de-anonymization is
+   caller-owned in every mode — `artifact_boundary.deanonymize_dir`, never
+   this agent.

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -571,32 +571,12 @@ def _generate_discovery_checkpoint(outputs_dir: Path, transcripts: list[Path]) -
     return checkpoint_path
 
 
-# Lean extraction format instructions shared across single and multi-transcript paths
-_LEAN_FORMAT = """
-IMPORTANT — Write findings in this LEAN structured format:
-
-## Summary
-[3-5 bullet points: the most important findings from this transcript]
-
-## Evidence Table
-| ID | Category | Finding | Severity | Line Ref |
-(One-line findings only. No full quotes — just reference the line number.)
-
-## Pain Points
-| ID | Description | Impact | Confidence |
-
-## Metrics
-| Name | Value | Source Line |
-
-## Stakeholder Positions
-| Name/Role | Key Stance |
-
-## Data Gaps
-[Bullet list of missing data or unanswered questions]
-
-TARGET SIZE: 8-15KB. Do NOT include source quotes, interpretation notes, or verbose descriptions.
-Do NOT write multi-line cells. Keep every table row on ONE line.
-"""
+# The lean extraction format (formerly the `_LEAN_FORMAT` f-string shared by the
+# single- and multi-transcript discovery prompts) now lives in the agent's own
+# contract: .claude/agents/discovery-transcript-interpreter.md, core section
+# "Lean Interim Extraction Format" — carried into every composed pipeline prompt.
+# _generate_discovery_checkpoint() below still depends on its heading contract
+# ("## Summary" ... breaks at "## Evidence"/"## Pain").
 
 
 async def step_discovery(
@@ -610,7 +590,8 @@ async def step_discovery(
     cost = 0.0
     inputs_dir = engagement_dir / "inputs"
     transcripts = sorted(inputs_dir.glob("transcript_*.md"))
-    intake = inputs_dir / "engagement_intake.md"
+    # (engagement_intake.md is now carried by the agent's pipeline mode contract
+    #  via the {engagement_dir} param — no inline prompt references it here.)
 
     if not transcripts:
         log("  ⚠ No transcripts found in inputs/", C.YELLOW)
@@ -647,23 +628,33 @@ async def step_discovery(
         mapping_file.chmod(0o600)  # Restrict access — this file contains PII
         log(f"    PII mapping saved ({len(combined_mapping)} substitutions)")
 
+    # discovery-transcript-interpreter is mode-extracted (skill-first contracts):
+    # prompts are composed from .claude/agents/discovery-transcript-interpreter.md
+    # (## Modes -> pipeline) via compose_prompt — no inline f-strings. Params
+    # carry VALUES only; out-of-phase params are explicit "(n/a — ...)" markers
+    # per the mode contract. The agent's inputs here are the ALREADY-anonymized
+    # .anon_transcript_* files produced above — anonymization stays
+    # orchestrator-owned (fail-closed, see the loop above), never agent-run.
+    def _interim_params(transcript: Path, index: int) -> dict:
+        return {
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "phase": "interim",
+            "transcript_path": transcript,
+            "transcript_index": index,
+            "transcript_count": len(transcripts),
+            "interim_files": "(n/a — interim phase)",
+        }
+
     if len(transcripts) == 1:
         # Single transcript: lean extraction -> Python checkpoint
-        prompt = f"""PHASE DIRECTIVE: Phase 1 of 2
-Engagement directory: {engagement_dir}
-
-Read and process this transcript: {transcripts[0]}
-Read the engagement context: {intake}
-
-Extract evidence items, pain points, metrics, and stakeholder intelligence.
-Write your findings to: {outputs_dir}/interim_transcript_1.md
-{_LEAN_FORMAT}
-"""
         result = await run_agent(
-            "discovery-transcript-interpreter", prompt,
+            "discovery-transcript-interpreter", None,
             cwd=engagement_dir,
             label="Discovery (1 transcript)",
             max_turns=15,
+            mode="pipeline",
+            params=_interim_params(transcripts[0], 1),
         )
         cost += result.total_cost_usd if result and result.total_cost_usd else 0
     else:
@@ -671,24 +662,13 @@ Write your findings to: {outputs_dir}/interim_transcript_1.md
         log(f"  Launching {len(transcripts)} transcript extractions in parallel...")
         extract_tasks = []
         for i, transcript in enumerate(transcripts, 1):
-            prompt = f"""PHASE DIRECTIVE: Phase 1 of 2 — Transcript {i} of {len(transcripts)}
-Engagement directory: {engagement_dir}
-
-Read and process ONLY this transcript: {transcript}
-Read the engagement context: {intake}
-
-Extract evidence items, pain points, metrics, and stakeholder intelligence.
-Write your findings ONLY to: {outputs_dir}/interim_transcript_{i}.md
-
-Do NOT write a checkpoint file. Do NOT read other transcripts or interim files.
-Focus only on this one transcript. Write the interim file and stop.
-{_LEAN_FORMAT}
-"""
             extract_tasks.append(run_agent(
-                "discovery-transcript-interpreter", prompt,
+                "discovery-transcript-interpreter", None,
                 cwd=engagement_dir,
                 label=f"Discovery (T{i}/{len(transcripts)})",
                 max_turns=15,
+                mode="pipeline",
+                params=_interim_params(transcript, i),
             ))
 
         # Fire all transcript extractions simultaneously
@@ -704,37 +684,28 @@ Focus only on this one transcript. Write the interim file and stop.
     # Checkpoint review — T2 FIX: was express=False, now express=express
     present_checkpoint("discovery", outputs_dir, express=express, non_interactive=non_interactive)
 
-    # Phase 2: Finalize registers — reads interims directly (NOT original transcripts)
+    # Phase 2: Finalize registers — reads interims directly (NOT original transcripts).
+    # Composed from the same ## Modes -> pipeline contract, phase "finalize";
+    # the enumerated interim list travels as a VALUES-only param.
     interim_files = sorted(outputs_dir.glob("interim_transcript_*.md"))
-    interim_list = chr(10).join(f'- {f}' for f in interim_files)
+    interim_list = ", ".join(str(f) for f in interim_files)
 
-    prompt = f"""PHASE DIRECTIVE: Phase 2 of 2 — Finalize Registers
-Engagement directory: {engagement_dir}
-
-Read the consultant approval: {outputs_dir}/CHECKPOINT_discovery_APPROVED.md
-
-Then read ALL interim files for detailed evidence:
-{interim_list}
-
-De-duplicate findings across transcripts (same point from multiple stakeholders = higher confidence).
-Incorporate any consultant feedback from the approval file.
-
-Do NOT read the original transcript files — the interims contain all extracted data you need.
-
-Produce these REQUIRED final output files (keep each file concise, under 20KB):
-- {outputs_dir}/evidence_register.md — consolidated evidence with IDs, categories, findings, severity
-- {outputs_dir}/pain_points.md — de-duplicated pain points ranked by impact
-- {outputs_dir}/metrics.md — all quantitative data extracted
-- {outputs_dir}/stakeholder_intelligence.md — key stakeholder positions and alignment
-
-You MUST write all four files. Do NOT write journal entries or update other files.
-"""
     # T1 FIX: added max_turns=15
     result = await run_agent(
-        "discovery-transcript-interpreter", prompt,
+        "discovery-transcript-interpreter", None,
         cwd=engagement_dir,
         label="Discovery (finalize)",
         max_turns=15,
+        mode="pipeline",
+        params={
+            "engagement_dir": engagement_dir,
+            "outputs_dir": outputs_dir,
+            "phase": "finalize",
+            "transcript_path": "(n/a — finalize phase)",
+            "transcript_index": "n/a",
+            "transcript_count": len(interim_files),
+            "interim_files": interim_list,
+        },
     )
     cost += result.total_cost_usd if result and result.total_cost_usd else 0
 


### PR DESCRIPTION
## Summary
PR 7 of the Skill-First Phase 1 cycle (Epic #98): discovery-transcript-interpreter extracted — the PII-sensitive entry agent, solo PR by design. The anonymization orchestration in step_discovery is byte-identical to parent (verified in spec review); only the agent prompts moved. 9 of 10 extractions complete.

## Tickets
- Closes #113 — B9: Extract discovery-transcript-interpreter (PII boundary)

## The PII contract (the point of this PR)
- **Pipeline mode:** inputs are the ALREADY-anonymized `.anon_transcript_*` files; anonymization stays orchestrator-owned (Python runs `anonymize_transcript.py` before any agent call, fail-closed skip on error, `.pii_mapping.json` chmod 600 — all unchanged) and hook-enforced. The agent contract states it never anonymizes and never reads raw transcripts.
- **Standalone mode:** documents `anonymize-guard.py`'s real scope (raw text reads under `engagements/*/inputs/`); pasted content is the consultant's responsibility; the agent never bypasses the guard.
- **Fail-open fallback REMOVED:** the `.md`'s old "if anonymization fails, proceed with the original transcript + log a warning" was structurally unreachable in pipeline mode (Python skips failed transcripts before the agent is ever called) and hook-blocked in standalone. Fail-closed everywhere, logged as a Decision-4 resolution in-file.
- **Synthetic round-trip demonstrated** (no real client data): anonymize → placeholders verified → composed prompts reference only `.anon_` paths → deanonymize with mapping restores; without mapping refuses loudly ("NOT client-ready").

## CONTRADICTION LOG (Decision 4)
1. Checkpoint ownership: `CHECKPOINT_discovery.md` is Python-generated (`_generate_discovery_checkpoint`) — never an agent output; the `.md`'s claim that the agent writes it was aspirational.
2. Pipeline outputs are exactly the four files legacy finalize named (evidence/pain/metrics/stakeholder-intelligence); the `.md`'s six-register set stays as the analytical spec in core and the standalone deliverable.
3. Journal suppression in BOTH pipeline phases — deliberate, disclosed divergence from the phase-single-only precedent: legacy finalize explicitly forbade journals; the multi-interim prompt ended write-and-stop; the silent single-interim variant was unified to the stricter form (disclosed in-file).
4. Fail-open fallback removal (above).
5. De-anonymization is caller-owned in every mode (`artifact_boundary.deanonymize_dir`).

## Also in this PR
- `_LEAN_FORMAT` moved from orchestrate.py into a core "Lean Interim Extraction Format" section (verbatim) — mode blocks can't carry H2 headings (parser constraint, now documented). `_generate_discovery_checkpoint` still parses the same heading contract.

## Focus Areas
- The step_discovery diff: prompt-construction blocks only — anonymization loop, mapping write, chmod, checkpoint generation, assert_file_exists all untouched (independently diffed).
- First agent with per-invocation-varying params (chunk path/index) — the `(n/a — …)` out-of-phase marker convention. Known cosmetic nit: `transcript_index`/`transcript_count` at the finalize call site pass bare `"n/a"` instead of the documented marker form — parked for /bb-refine.

## Risk Flags
- [ ] Breaking changes: no
- [ ] Migration needed: no
- [x] Affects existing behavior: fail-open fallback removed (was unreachable; now contractually fail-closed)

## CI Coverage
- test_agent.py 140/140; unit 1.000; pipeline 1.000; gate BLOCKING post-#92

## Testing
- 22 interim + 18 finalize composed-vs-legacy instruction checks — zero lost
- PII round-trip on synthetic fixtures (documented in #113)
- NOT tested: live SDK invocation through the mode path (cycle-wide caveat)

## Base-branch note
Stacked on `mariamt/20260724-skill-first-pr6` (PR #121). Review order: #92 → #116 → #117 → #118 → #119 → #120 → #121 → this.
