### PR TITLE
feat(synthetic-quarantine): PR 2 — read-side exclusion: [Synthetic-Test] tier, retrieval sweep, librarian fix (#133-#134)

### DIFF
--- a/.claude/agents/benchmark-librarian.md
+++ b/.claude/agents/benchmark-librarian.md
@@ -73,6 +73,8 @@ When you encounter a benchmark with field observations:
 
 5. **Date everything.** Benchmark age matters. Always include the source date and flag benchmarks older than 3 years.
 
+6. **Synthetic-data exclusion.** Never serve a benchmark tagged `[Synthetic-Test]` or sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`) — it is fabricated pipeline-test data, not a low-confidence tier. If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 ## Workflow
 
 1. **Receive Request:** Understand the engagement context (domain, region, specific metrics needed)
@@ -134,6 +136,7 @@ Before finalizing any benchmark shortlist, verify:
 - [ ] Downstream agents (ROI, Capability) can use the shortlist without additional sourcing
 - [ ] Assumptions register included for any derived or adjusted benchmark values
 - [ ] Benchmark IDs are consistent and unique for cross-referencing by downstream agents
+- [ ] No `[Synthetic-Test]`-tagged or `tests/`-sourced entry is served (see `knowledge/standards/benchmark_evolution.md`); canonical excluded-count note appended if ≥1 entry was excluded, omitted if none were
 
 ## Anti-Patterns to Avoid
 
@@ -197,9 +200,6 @@ inputs:
     - outputs/stakeholder_intelligence.md
 degraded: proceed-without
 knowledge:
-  - benchmarks/benchmark_registry.md
-  - benchmarks/regions/*
-  - benchmarks/domains/*
   - knowledge/domains/*/benchmarks.md
   - knowledge/standards/benchmark_evolution.md
   - knowledge/learnings/benchmarks/*
@@ -234,9 +234,6 @@ inputs:
 degraded: refuse
 knowledge:
   - knowledge/domains/{domain}/benchmarks.md
-  - benchmarks/benchmark_registry.md
-  - benchmarks/regions/*
-  - benchmarks/domains/*
   - knowledge/standards/benchmark_evolution.md
   - knowledge/learnings/benchmarks/*
 outputs:

--- a/.claude/agents/roi-business-case-builder.md
+++ b/.claude/agents/roi-business-case-builder.md
@@ -442,10 +442,10 @@ config = {
 }
 
 generator = ROIModelGenerator(config)
-generator.generate("outputs/2602_Zenith_Nigeria_ROI_Model.xlsx")
+generator.generate("outputs/2602_Client_Country_ROI_Model.xlsx")
 ```
 
-> **IMPORTANT — Output file naming:** Always use the convention `YYMM_[CLIENT_CODE]_ROI_Model.xlsx` where `YYMM` is the year+month of generation (e.g. `2602` = February 2026) and `CLIENT_CODE` is the engagement directory prefix (e.g. `Zenith_Nigeria`). Example: `outputs/2602_Zenith_Nigeria_ROI_Model.xlsx`.
+> **IMPORTANT — Output file naming:** Always use the convention `YYMM_[CLIENT_CODE]_ROI_Model.xlsx` where `YYMM` is the year+month of generation (e.g. `2602` = February 2026) and `CLIENT_CODE` is the engagement directory prefix (e.g. `Client_Country`). Example: `outputs/2602_Client_Country_ROI_Model.xlsx`.
 
 > **IMPORTANT — Config field names:** The Excel generator reads `assumptions_register` and `data_gaps_for_validation` as the canonical top-level keys. The generator also accepts `assumptions` and `data_gaps` as fallbacks, but always prefer the canonical names for new configs.
 

--- a/.claude/agents/roi-financial-modeler.md
+++ b/.claude/agents/roi-financial-modeler.md
@@ -40,6 +40,8 @@ Optional but recommended:
 9. **Ramp-up models** — `knowledge/standards/ramp_up_models.md`
 10. **Benchmark evolution rules** — `knowledge/standards/benchmark_evolution.md`
 
+> **Synthetic-data exclusion:** when reading domain benchmarks, ROI levers, or `knowledge/learnings/`, exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 ## Backbase Product Knowledge (MCP)
 
 Use MCP tools (`mcp__backbase-infobank__*`) to validate Backbase capabilities named in lever candidates. Every lever that claims "Backbase enables X" should be verifiable. If MCP unavailable, fall back to domain `roi_levers.md` enabler sections.

--- a/.claude/agents/roi-hypothesis-builder.md
+++ b/.claude/agents/roi-hypothesis-builder.md
@@ -131,6 +131,8 @@ Read the relevant product directory (`knowledge/domains/product_directory_{domai
 **Source 5: Check analogous engagement patterns**
 Read `knowledge/learnings/roi_models/*.md` for proven lever patterns from similar engagements. Also check existing engagement configs in `engagements/outputs/*/roi_config.json` for what levers consultants found for comparable clients.
 
+> **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 ---
 
 **For EVERY creative lever, you MUST document (following BECU model pattern):**

--- a/.claude/commands/domain-benchmarks.md
+++ b/.claude/commands/domain-benchmarks.md
@@ -30,6 +30,8 @@ When this skill is invoked:
 
 1. **Read the master benchmark file**: `knowledge/Consulting Playbook Metrics Benchmark [Master] - Benchmarks.csv`
 
+   > **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 2. **Filter by domain-relevant journeys**:
    - **Retail/SME:** General, Digital Onboarding, Loan Origination, Cards, Online Registration, Payments, Deposits & Loans, Transaction Dispute, Loan Servicing
    - **Investing:** Account Opening, Digital Adoption, Revenue & AUM, Operational Efficiency, Customer Experience (benchmarks use confidence tiers: `[Industry]`/`[Proxy]`/`[Estimated]`/`[Client-Validated]`)

--- a/.claude/commands/domain-context.md
+++ b/.claude/commands/domain-context.md
@@ -29,6 +29,8 @@ When this skill is invoked:
    - `pain_points.md` - Common challenges
    - `value_propositions.md` - Backbase solutions
 
+   > **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 3. **Summarize the domain context** for the user, highlighting:
    - Key themes and focus areas
    - Available benchmarks

--- a/.claude/commands/domain-journeys.md
+++ b/.claude/commands/domain-journeys.md
@@ -24,6 +24,8 @@ When this skill is invoked:
 
 1. **Load the journey maps file** from `knowledge/domains/[domain]/journey_maps.md`
 
+   > **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 2. **Filter by journey type** if specified
 
 3. **Present journeys** with:

--- a/.claude/commands/domain-pain-points.md
+++ b/.claude/commands/domain-pain-points.md
@@ -15,6 +15,8 @@ When this skill is invoked:
 
 1. **Load the pain points file** from `knowledge/domains/[domain]/pain_points.md`
 
+   > **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 2. **Filter by perspective** if specified:
    - `customer` - End customer/client pain points
    - `bank` - Internal bank challenges (operational, technology, business)

--- a/.claude/commands/domain-usecases.md
+++ b/.claude/commands/domain-usecases.md
@@ -24,6 +24,8 @@ When this skill is invoked:
 
 1. **Load the use cases file** from `knowledge/domains/[domain]/use_cases.md`
 
+   > **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 2. **Filter by category** if specified
 
 3. **Present use cases** with:

--- a/.claude/commands/domain-value-props.md
+++ b/.claude/commands/domain-value-props.md
@@ -24,6 +24,8 @@ When this skill is invoked:
 
 1. **Load the value propositions file** from `knowledge/domains/[domain]/value_propositions.md`
 
+   > **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 2. **Filter by theme** if specified
 
 3. **Present value propositions** with:

--- a/.claude/commands/generate-roi-excel.md
+++ b/.claude/commands/generate-roi-excel.md
@@ -182,6 +182,8 @@ See `.claude/agents/roi-financial-modeler.md` for the full authoritative schema 
 
 **Reference Data:** `knowledge/learnings/roi_models/tech_rationalization_decommission.md`
 
+> **Synthetic-data exclusion:** exclude any `[Synthetic-Test]`-tagged entry and anything sourced from a `tests/` path (see `knowledge/standards/benchmark_evolution.md`). If ≥1 entry was excluded, append that standard's canonical excluded-count note; if nothing was excluded, add no note.
+
 ### Tech Rationalization Sheet Structure
 
 | Section | Content |

--- a/evals/goldens/benchmark_golden.md
+++ b/evals/goldens/benchmark_golden.md
@@ -55,3 +55,7 @@ appropriately.
   center analytics before use in a client-facing deliverable.
 - Regulator-sourced attrition data (row 5) is sector-wide, not segmented by
   asset size — treat as directional only.
+- One candidate metric from the initial search was excluded as synthetic
+  pipeline-test data before this shortlist was compiled.
+
+Note: 1 synthetic-test entry excluded — fabricated pipeline-test data, never citable in client work (see knowledge/standards/benchmark_evolution.md).

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -162,7 +162,7 @@ components:
     threshold: 0.80
     # Re-pointed from bare `nfis` (gitignored, vacuous) to a committed synthetic golden.
     input: evals/goldens/benchmark_golden.md   # scores specifics._benchmark via rubrics.component.benchmark_librarian
-    code: [confidence_levels_present, source_attribution_present]
+    code: [confidence_levels_present, source_attribution_present, no_synthetic_citations]
     judge: [benchmarks_defensible_not_hallucinated]
 
   usecase-designer:

--- a/evals/rubrics/component/specifics.py
+++ b/evals/rubrics/component/specifics.py
@@ -444,6 +444,37 @@ def _journey(text: str) -> list[CheckResult]:
     return out
 
 
+# Canonical excluded-count note format (knowledge/standards/benchmark_evolution.md):
+#   "Note: N synthetic-test entr(y/ies) excluded — fabricated pipeline-test
+#   data, never citable in client work (see knowledge/standards/benchmark_evolution.md)."
+# A line matching this format is the expected way to ACKNOWLEDGE an exclusion
+# and is not itself a stray citation.
+_SYNTHETIC_NOTE_RE = re.compile(
+    r"^note:\s*\d+\s*synthetic-test entr(?:y|ies)\s*excluded\s*.{0,5}"
+    r"fabricated pipeline-test data.*benchmark_evolution\.md\)\.?\s*$",
+    re.I,
+)
+
+
+def _no_synthetic_citations(text: str) -> CheckResult:
+    """Zero [Synthetic-Test] citations outside an explicit excluded-count note line.
+
+    Honest limitation: this pins the FIXTURE's content contract for the eval —
+    it does not verify the live agent's retrieval behavior. The eval gate
+    scores goldens; it does not execute the agent or its knowledge reads
+    (see memory/eval-gate-is-path2-only.md).
+    """
+    stray = [line.strip() for line in text.splitlines()
+             if re.search(r"synthetic[- ]test", line, re.I)
+             and not _SYNTHETIC_NOTE_RE.match(line.strip())]
+    ok = not stray
+    return _bool_check(
+        "no_synthetic_citations", ok,
+        detail="no stray [Synthetic-Test] citations outside the canonical excluded-count note" if ok
+        else f"{len(stray)} line(s) reference synthetic-test data outside the canonical note",
+    )
+
+
 # ---------------------------------------------------------------------------
 # benchmark-librarian
 #   yaml: confidence levels (High/Medium/Low confidence); source attribution.
@@ -458,6 +489,7 @@ def _benchmark(text: str) -> list[CheckResult]:
                      r"not available|consultant-provided|industry|proxy|estimated)[^\]]*\]", text)
     out.append(_ratio_check("source_attribution_present", min(sources, 3), 3,
                             detail=f"{sources} source: / provenance tags"))
+    out.append(_no_synthetic_citations(text))
     return out
 
 

--- a/knowledge/standards/benchmark_evolution.md
+++ b/knowledge/standards/benchmark_evolution.md
@@ -16,6 +16,19 @@ Every benchmark value carries a confidence tier. The tier determines how the val
 | **2** | `[Proxy]` | From an adjacent domain, region, or time period. Reasonable but not exact. | Use with 20% conservative haircut. Flag in assumptions. | "Proxy benchmark: [value] (adjusted from [original context])" |
 | **3** | `[Estimated]` | Derived from logic, analogies, or expert judgment. No direct empirical source. | Use as directional only. Wide confidence interval (±30-50%). | "Estimated: [range] (basis: [reasoning])" |
 | **4** | `[Client-Validated]` | Confirmed by actual client data during an engagement. The gold standard. | Direct use. Highest confidence. | "Client-validated: [value] ([anonymized engagement ref])" |
+| **Excluded** | `[Synthetic-Test]` | Fabricated data from synthetic test engagements (`tests/engagements/`). | **NEVER.** Excluded from all retrieval. Not promotable. | Not displayed — excluded before presentation. |
+
+### `[Synthetic-Test]` — excluded tier detail
+
+**Provenance:** entries tagged `[Synthetic-Test]`, and anything sourced from a `tests/` path, originate from `tests/engagements/` — fictional engagements (e.g. Harborlight, Zenith demo fixtures) used to exercise the pipeline. They are marked with a `.synthetic` file at the engagement root. See `tests/engagements/README.md` for the full quarantine mechanism.
+
+**Retrieval exclusion rule (canonical wording — referenced, not restated, by every retrieval surface):** when reading knowledge sources, exclude any entry tagged `[Synthetic-Test]` and anything sourced from a `tests/` path. This data must never be cited in ROI models, client deliverables, or benchmark comparisons — it is not a low-confidence tier to be used cautiously, it is fabricated pipeline-test data and cannot be promoted to any real tier.
+
+**Canonical excluded-count note** (append when ≥1 entry was excluded; omit entirely when nothing was excluded):
+
+```
+Note: N synthetic-test entr(y/ies) excluded — fabricated pipeline-test data, never citable in client work (see knowledge/standards/benchmark_evolution.md).
+```
 
 ---
 


### PR DESCRIPTION
## Summary
Read-side enforcement for the synthetic-engagement quarantine (PRD v4): `[Synthetic-Test]` formalized as an excluded tier in the canonical benchmark standard, an exclusion-with-visible-note rule added to every retrieval surface (6 `domain-*` commands, `/generate-roi-excel`, both live ROI agents, benchmark-librarian), the librarian's phantom `benchmarks/*` whitelist paths removed (folded backlog item), and the Zenith example swapped out of the deprecated ROI builder.

**Stack: PR 2 of 3.** Base = `mariamt/20260818-sq-pr1-write` (#138). Merge after PR 1.

## Tickets
- Closes #133 — Retrieval exclusion: [Synthetic-Test] canonical tier + rule sweep across domain-* and ROI surfaces
- Closes #134 — Benchmark-librarian: synthetic exclusion rule + phantom benchmarks/ whitelist fix + no_synthetic_citations eval

## Approach
One canonical definition, referenced everywhere. The tier row + provenance + canonical excluded-count note format live in `knowledge/standards/benchmark_evolution.md`; each surface gets a short additive rule block pointing back to it (exclude `[Synthetic-Test]` tags and `tests/`-sourced values; ≥1 excluded → append the count note, else silent). Exclusion is visible by owner decision — a rising excluded-count is itself a contamination alarm. The librarian additionally loses three whitelist paths that have never existed in the repo (`benchmarks/benchmark_registry.md`, `benchmarks/regions/*`, `benchmarks/domains/*`); `knowledge/learnings/benchmarks/` was verified REAL (holds HARVEST_TEMPLATE.md) and kept. Its eval gains a `no_synthetic_citations` code check with a positive witness line in the golden.

## Focus Areas
- Integration: ROI agents' rule blocks sit in the shared body ABOVE `## Modes` (composer constraint); the librarian's remaining whitelists must still cover every real path it needs (the 2026-07-28 whitelist restore survives).
- Edge cases: the `no_synthetic_citations` regex counts a canonical note line as legal, any other `[Synthetic-Test]` mention as a citation.
- The 4 existing tier definitions are byte-identical — only additive changes.

## Risk Flags
- [ ] Breaking changes: no.
- [ ] Migration needed: no.
- [x] Affects existing behavior: retrieval surfaces now filter + annotate; librarian reads from a corrected whitelist.

## Skip List
- `roi-business-case-builder.md` — deprecated file; only the example filename changed by design (tombstoning is parked for skill-first Phase 3).

## CI Coverage
- Structural agent checks 86/86 at branch head
- Eval harness: benchmark-librarian 1.000/0.80 (incl. new check), roi-hypothesis-builder 1.000/0.80, roi-financial-modeler 1.000/0.80, pipeline 1.000/0.90
- Honest limitation (by design, documented in the rubric): component evals score committed fixtures, not live agent runs — the rule text is the enforcement, the eval pins the contract.

## Testing
- Greps verified: zero `Zenith` in the deprecated builder; zero phantom paths in the librarian; exactly one rule block per surface; 4 banner-marked roi_models files untouched.
