### PR TITLE
feat(synthetic-quarantine): PR 3 — backstops: CI structural checks + synthetic-knowledge-guard hook (#135-#136)

### DIFF
--- a/.claude/hooks/synthetic-knowledge-guard.py
+++ b/.claude/hooks/synthetic-knowledge-guard.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+PreToolUse(Edit|Write) hook — the synthetic-engagement content guard.
+
+Stops synthetic/fictional engagement material from contaminating the shared
+knowledge base. `knowledge/` is read by every downstream engagement (via
+domain-*, benchmark-librarian, etc.) — anything written there is treated as
+real, citable ground truth. Synthetic engagements (Harborlight, Zenith-style
+fixtures, demos) exist under `tests/engagements/` precisely so they never mix
+with `knowledge/`. See `tests/engagements/README.md` for the quarantine model.
+
+This hook is the belt-and-braces content backstop behind that convention: it
+inspects the CONTENT of an incoming Write/Edit under `knowledge/` for two
+markers that should never legitimately land there:
+  - `[Synthetic-Test]` under `knowledge/domains/` — the explicit synthetic tier
+    tag (legal under `knowledge/learnings/` and `knowledge/standards/`, where
+    it documents the tier itself; not legal inside domain content, which is
+    read as real benchmark/pattern data).
+  - `Harborlight` (case-sensitive) anywhere under `knowledge/` — the fictional
+    bank name used across synthetic fixtures/demos. As of the synthetic-
+    quarantine cleanup, no legitimate knowledge/ file contains this word, so
+    the check has zero standing false-positive surface.
+
+Design rules (mirroring the other hooks in this directory):
+  - Deliberately NARROW: only `knowledge/**`, only two content markers. This
+    is a content heuristic, not provenance tracing — it cannot catch
+    unlabeled synthetic numbers, only these two known contamination markers.
+  - FAIL-OPEN on any error. A guard must never wedge the session: on any
+    exception we allow, exactly like anonymize-guard.py and require-harness.py.
+  - Covers BOTH interactive sessions and the automated pipeline: project
+    settings (and therefore PreToolUse hooks) load by default regardless of
+    permission mode, so this backstop applies even under a non-interactive
+    `bypassPermissions` pipeline run.
+
+Decision contract (stdout JSON, exit 0):
+  - allow -> emit nothing
+  - deny  -> emit {"hookSpecificOutput": {permissionDecision: "deny", ...}}
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", Path.cwd()))
+
+SYNTHETIC_TAG = "[Synthetic-Test]"
+FICTIONAL_NAME = "Harborlight"
+
+
+def _allow():
+    sys.exit(0)
+
+
+def _deny(reason: str):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def _resolve(raw: str) -> Path:
+    p = Path(raw)
+    if not p.is_absolute():
+        p = PROJECT_DIR / p
+    try:
+        return p.resolve()
+    except OSError:
+        return p
+
+
+def _rel(p: Path) -> str:
+    try:
+        return p.relative_to(PROJECT_DIR.resolve()).as_posix()
+    except ValueError:
+        try:
+            return p.relative_to(PROJECT_DIR).as_posix()
+        except ValueError:
+            return p.as_posix()
+
+
+def _deny_message(rel: str, marker: str) -> str:
+    return (
+        f"🛑 Synthetic-knowledge guard: '{rel}' would write content containing "
+        f"'{marker}' into the shared knowledge base. This marker identifies "
+        f"synthetic/fictional engagement material, which must stay quarantined "
+        f"away from knowledge/ (real engagements read this content as ground "
+        f"truth). See tests/engagements/README.md for where synthetic fixtures "
+        f"belong and how the quarantine model works."
+    )
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+
+    tool = payload.get("tool_name")
+    if tool not in ("Write", "Edit"):
+        _allow()
+
+    tool_input = payload.get("tool_input", {}) or {}
+    raw = tool_input.get("file_path")
+    if not raw:
+        _allow()
+
+    p = _resolve(raw)
+    rel = _rel(p)
+
+    # Path prefilter: only knowledge/** is in scope.
+    if not (rel == "knowledge" or rel.startswith("knowledge/")):
+        _allow()
+
+    if tool == "Write":
+        content = tool_input.get("content", "") or ""
+    else:  # Edit
+        content = tool_input.get("new_string", "") or ""
+
+    if FICTIONAL_NAME in content:
+        _deny(_deny_message(rel, FICTIONAL_NAME))
+
+    if SYNTHETIC_TAG in content and (rel == "knowledge/domains" or rel.startswith("knowledge/domains/")):
+        _deny(_deny_message(rel, SYNTHETIC_TAG))
+
+    _allow()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        # Never wedge the session on a guard bug — fail OPEN.
+        sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,15 @@
             "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/require-harness.py"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/synthetic-knowledge-guard.py"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/knowledge/learnings/roi_models/call_deflection_roi.md
+++ b/knowledge/learnings/roi_models/call_deflection_roi.md
@@ -1,7 +1,7 @@
 # ROI Pattern: Call Center Deflection via Digital Self-Service
 
 > ⚠️ **SYNTHETIC-ORIGIN PATTERN — the numbers in this file are NOT real client data.**
-> Harvested from a synthetic pipeline-test engagement ("Harborlight", 2026-07 — a fictional NAM credit union invented to validate the assessment pipeline).
+> Harvested from a synthetic pipeline-test engagement — a fictional NAM credit union invented to validate the assessment pipeline (2026-07 synthetic test engagement; see tests/engagements/README.md).
 > The value-lever structure, formulas, and applicability logic are reusable methodology and may be applied to real engagements.
 > Every value tagged [Synthetic-Test] is fabricated. NEVER cite these numbers as benchmarks, baselines, or client-validated data in client work — source real figures from knowledge/domains/ or the Consulting Playbook Master benchmarks instead. (Values tagged [Client-Validated, ref] reference real named Backbase clients and remain valid.)
 

--- a/knowledge/learnings/roi_models/card_controls_roi.md
+++ b/knowledge/learnings/roi_models/card_controls_roi.md
@@ -1,7 +1,7 @@
 # ROI Pattern: In-App Card Controls Deployment
 
 > ⚠️ **SYNTHETIC-ORIGIN PATTERN — the numbers in this file are NOT real client data.**
-> Harvested from a synthetic pipeline-test engagement ("Harborlight", 2026-07 — a fictional NAM credit union invented to validate the assessment pipeline).
+> Harvested from a synthetic pipeline-test engagement — a fictional NAM credit union invented to validate the assessment pipeline (2026-07 synthetic test engagement; see tests/engagements/README.md).
 > The value-lever structure, formulas, and applicability logic are reusable methodology and may be applied to real engagements.
 > Every value tagged [Synthetic-Test] is fabricated. NEVER cite these numbers as benchmarks, baselines, or client-validated data in client work — source real figures from knowledge/domains/ or the Consulting Playbook Master benchmarks instead. (Values tagged [Client-Validated, ref] reference real named Backbase clients and remain valid.)
 

--- a/knowledge/learnings/roi_models/digital_onboarding_completion_roi.md
+++ b/knowledge/learnings/roi_models/digital_onboarding_completion_roi.md
@@ -1,7 +1,7 @@
 # ROI Pattern: Digital Membership / Account Onboarding Completion
 
 > ⚠️ **SYNTHETIC-ORIGIN PATTERN — the numbers in this file are NOT real client data.**
-> Harvested from a synthetic pipeline-test engagement ("Harborlight", 2026-07 — a fictional NAM credit union invented to validate the assessment pipeline).
+> Harvested from a synthetic pipeline-test engagement — a fictional NAM credit union invented to validate the assessment pipeline (2026-07 synthetic test engagement; see tests/engagements/README.md).
 > The value-lever structure, formulas, and applicability logic are reusable methodology and may be applied to real engagements.
 > Every value tagged [Synthetic-Test] is fabricated. NEVER cite these numbers as benchmarks, baselines, or client-validated data in client work — source real figures from knowledge/domains/ or the Consulting Playbook Master benchmarks instead. (Values tagged [Client-Validated, ref] reference real named Backbase clients and remain valid.)
 

--- a/knowledge/learnings/roi_models/dispute_management_roi.md
+++ b/knowledge/learnings/roi_models/dispute_management_roi.md
@@ -1,7 +1,7 @@
 # ROI Pattern: Dispute Management Automation
 
 > ⚠️ **SYNTHETIC-ORIGIN PATTERN — the numbers in this file are NOT real client data.**
-> Harvested from a synthetic pipeline-test engagement ("Harborlight", 2026-07 — a fictional NAM credit union invented to validate the assessment pipeline).
+> Harvested from a synthetic pipeline-test engagement — a fictional NAM credit union invented to validate the assessment pipeline (2026-07 synthetic test engagement; see tests/engagements/README.md).
 > The value-lever structure, formulas, and applicability logic are reusable methodology and may be applied to real engagements.
 > Every value tagged [Synthetic-Test] is fabricated. NEVER cite these numbers as benchmarks, baselines, or client-validated data in client work — source real figures from knowledge/domains/ or the Consulting Playbook Master benchmarks instead. (Values tagged [Client-Validated, ref] reference real named Backbase clients and remain valid.)
 

--- a/knowledge/standards/benchmark_evolution.md
+++ b/knowledge/standards/benchmark_evolution.md
@@ -20,7 +20,7 @@ Every benchmark value carries a confidence tier. The tier determines how the val
 
 ### `[Synthetic-Test]` — excluded tier detail
 
-**Provenance:** entries tagged `[Synthetic-Test]`, and anything sourced from a `tests/` path, originate from `tests/engagements/` — fictional engagements (e.g. Harborlight, Zenith demo fixtures) used to exercise the pipeline. They are marked with a `.synthetic` file at the engagement root. See `tests/engagements/README.md` for the full quarantine mechanism.
+**Provenance:** entries tagged `[Synthetic-Test]`, and anything sourced from a `tests/` path, originate from `tests/engagements/` — fictional engagements (e.g. Zenith demo fixtures) used to exercise the pipeline. They are marked with a `.synthetic` file at the engagement root. See `tests/engagements/README.md` for the full quarantine mechanism.
 
 **Retrieval exclusion rule (canonical wording — referenced, not restated, by every retrieval surface):** when reading knowledge sources, exclude any entry tagged `[Synthetic-Test]` and anything sourced from a `tests/` path. This data must never be cited in ROI models, client deliverables, or benchmark comparisons — it is not a low-confidence tier to be used cautiously, it is fabricated pipeline-test data and cannot be promoted to any real tier.
 

--- a/scripts/test_agent.py
+++ b/scripts/test_agent.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import argparse
+import fnmatch
 import json
 import os
 import re
@@ -86,6 +87,21 @@ def check_file(filepath: str, checks: list) -> list:
         })
 
     return results
+
+
+def check_applies_to(filepath: str, check: dict) -> bool:
+    """Whether a check's optional `applies_to` glob matches this file.
+
+    No `applies_to` means the check applies to every file of its type
+    (existing behavior). Matching uses fnmatch, which is path-separator
+    agnostic — e.g. "knowledge/domains/**" matches
+    "knowledge/domains/retail/benchmarks.md".
+    """
+    applies_to = check.get('applies_to')
+    if not applies_to:
+        return True
+    patterns = applies_to if isinstance(applies_to, list) else [applies_to]
+    return any(fnmatch.fnmatch(filepath, pattern) for pattern in patterns)
 
 
 def determine_file_type(filepath: str) -> str:
@@ -301,7 +317,9 @@ def run_checks(files: list, metrics: dict) -> dict:
             # We only check definition structure here.
 
         elif file_type == 'knowledge':
-            checks_to_run.extend(metrics.get('knowledge_files', {}).get('structural', []))
+            for check in metrics.get('knowledge_files', {}).get('structural', []):
+                if check_applies_to(filepath, check):
+                    checks_to_run.append(check)
 
         if not checks_to_run:
             continue

--- a/tests/quality_metrics.yaml
+++ b/tests/quality_metrics.yaml
@@ -204,6 +204,17 @@ knowledge_files:
       max_matches: 0
       description: "Knowledge files should use anonymized references"
 
+    - name: "No [Synthetic-Test] data in domain knowledge"
+      pattern: "\\[Synthetic-Test\\]"
+      max_matches: 0
+      applies_to: "knowledge/domains/**"
+      description: "Fabricated data from synthetic pipeline-test engagements must never reach domain knowledge — see tests/engagements/README.md"
+
+    - name: "No fictional test-bank names in knowledge"
+      pattern: "\\bHarborlight\\b"
+      max_matches: 0
+      description: "Harborlight is a fictional synthetic-test bank invented to exercise the pipeline; it must never be cited as a real client — see tests/engagements/README.md"
+
     - name: "Has confidence levels for benchmarks"
       pattern: "[Hh]igh|[Mm]edium|[Ll]ow"
       min_matches: 1


### PR DESCRIPTION
## Summary
Backstop layer for the synthetic-engagement quarantine (PRD v4): two $0 CI structural checks that fail any `knowledge/**` PR carrying synthetic contamination, and a fail-open PreToolUse hook (`synthetic-knowledge-guard.py`) that denies contaminating writes in interactive AND SDK pipeline sessions. Includes a latent-bug fix discovered en route: `quality_metrics.yaml`'s `applies_to` field was declared but never evaluated by `test_agent.py` — it now is.

**Stack: PR 3 of 3.** Base = `mariamt/20260818-sq-pr2-read` (#139). Merge last.

## Tickets
- Closes #135 — CI backstop: knowledge_files structural checks for synthetic contamination
- Closes #136 — Hook backstop: synthetic-knowledge-guard.py PreToolUse content guard + SDK canary verification

## Approach
CI: "No [Synthetic-Test] data in domain knowledge" (scoped via `applies_to: knowledge/domains/**` — the banner-marked `learnings/roi_models` files and the tier standard stay legal) and "No fictional test-bank names in knowledge" (`\bHarborlight\b`, all knowledge files). Deliberately NO Zenith pattern — Zenith Bank is a real Nigerian institution (Design Decision 6). To make the Harborlight tripwire a zero-false-positive invariant, the 5 knowledge banners that legitimately named the fictional bank were reworded (d92dd0d) — the `[Synthetic-Test]` tag carries the machine-readable signal; warnings otherwise intact. Hook: mirrors `anonymize-guard.py` (stdin JSON, `_allow`/`_deny`, path prefilter, fail-open with the repo's standard rationale comment); scans Write `content` / Edit `new_string` only — so edits that REMOVE contamination are never blocked. Hook viability was doc-verified: the SDK loads project settings by default and PreToolUse denies are NOT bypassed by `bypassPermissions`.

## Focus Areas
- Security/enforcement: the hook is belt-and-braces, not load-bearing — the Python gate (PR 1) + CI checks carry enforcement even if a hook is skipped.
- Edge cases: `applies_to` fnmatch scoping (proven end-to-end by witness runs); case-sensitivity — lowercase `harborlight_synthetic` directory ids in EXTRACTION_REGISTRY do not trip `\bHarborlight\b`.
- The `test_agent.py` patch side effect: the pre-existing benchmarks-confidence check is now correctly scoped to `**/benchmarks.md` (it previously fired on every knowledge file with a permissive pattern — harmless before, correct now).

## Risk Flags
- [ ] Breaking changes: no.
- [ ] Migration needed: no.
- [x] Affects existing behavior: `knowledge/**` PRs face two new named checks; Write/Edit to knowledge/ passes through one more (fail-open) hook.

## Skip List
- The banner rewording (d92dd0d) — orchestrator-authorized amendment to keep Check 2 exemption-free; verified not to weaken any warning.

## CI Coverage
- Structural 86/86 at branch head; knowledge-harvester 1.000/1.00; benchmark-librarian 1.000/0.80; pipeline 1.000/0.90
- Witness runs (documented in #135): [Synthetic-Test]-in-domains scratch diff FAILS the named check; Harborlight-anywhere FAILS; banner-marked files pass.

## Testing
- Hook: all 7 direct stdin canaries exact (2 denies with correct JSON + message; scoped allows for learnings/standards/tests paths; fail-open on garbage stdin); reviewer independently re-ran all 7 plus case-sensitivity and old_string-removal probes.
- NOT tested live: the hook firing inside a real SDK pipeline session — the build sandbox refuses nested Claude Code sessions (CLAUDECODE set). **Pre-merge checklist (shared with PR 1):** from a normal terminal, run the #132 harvest witness (which exercises the full SDK path with the hook wired) and optionally the #136 SDK canary.
